### PR TITLE
[dev] gitignore more project specific entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,34 @@
 target/*
 work/*
-.settings/*
+/bin/*
+
+# Java
+*.class
+*.jar
+*.war
+*.ear
+
+# Eclipse
+.settings/
+.buildpath
 .classpath
 .project
+
+# Logging
+*.log
+
 .idea
 *.iml
+
+# Mac OS X
 .DS_Store
-**/.DS_Store
 
 etc/*
 node/*
 node_modules/*
 /npm-debug.log
 /yarn.lock
+
+# Linux backup files
+*~
 


### PR DESCRIPTION
When working locally, there are compiled class files and bin/ stuff detected as git changes. Hence, this PR adds some more Java specfic entries.