### PR TITLE
[push] new filter option: triggerOnlyIfTagPush (cloud + server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ bitbucketTriggers {
   // For Bitbucket Cloud
   repositoryPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String)
   repositoryPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String, isToApprove: boolean)
+  repositoryPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String, isToApprove: boolean, triggerOnlyIfTagPush: boolean)
 
   pullRequestApprovedAction(onlyIfReviewersApproved: boolean)
   pullRequestApprovedAction(onlyIfReviewersApproved: boolean, allowedBranches: String)
@@ -178,6 +179,7 @@ bitbucketTriggers {
   // note: flag `isToApprove` has no effect yet
   repositoryServerPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String)
   repositoryServerPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String, isToApprove: boolean)
+  repositoryServerPushAction(triggerAlsoIfTagPush: boolean, triggerAlsoIfNothingChanged: boolean, allowedBranches: String, isToApprove: boolean, triggerOnlyIfTagPush: boolean)
 
   pullRequestServerApprovedAction(onlyIfReviewersApproved: boolean)
   pullRequestServerApprovedAction(onlyIfReviewersApproved: boolean, allowedBranches: String)

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
@@ -64,6 +64,10 @@ public interface BitBucketPPRAction extends Action {
     return null;
   }
 
+  public default String getTargetBranchRefId() {
+    return null;
+  }
+
   public default String getType() {
     return null;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
@@ -39,7 +39,8 @@ public class BitBucketPPRServerRepositoryAction extends InvisibleAction implemen
 
   private final @Nonnull BitBucketPPRPayload payload;
   private List<String> scmUrls = new ArrayList<>(2);
-  private String targetBranch = null;
+  private String targetBranchName = null;
+  private String targetBranchRefId = null;
   private String type;
 
   public BitBucketPPRServerRepositoryAction(BitBucketPPRPayload payload) {
@@ -59,20 +60,26 @@ public class BitBucketPPRServerRepositoryAction extends InvisibleAction implemen
 
     for (BitBucketPPRServerChange change : payload.getServerChanges()) {
       if (change.getRefId() != null) {
-        this.targetBranch = change.getRefId();
-        this.type = change.getType();
+        this.targetBranchName = change.getRef().getDisplayId();
+        this.targetBranchRefId = change.getRefId();
+        this.type = change.getRef().getType();
         break;
       }
     }
 
     LOGGER.log(Level.INFO,
-        () -> "Received commit hook notification from server for destination branch: " + this.targetBranch);
+        () -> "Received commit hook notification from server for destination branch: " + this.targetBranchName);
     LOGGER.log(Level.INFO, () -> "Received commit hook type from server: " + this.type);
   }
 
   @Override
   public String getTargetBranch() {
-    return targetBranch;
+    return targetBranchName;
+  }
+
+  @Override
+  public String getTargetBranchRefId() {
+    return targetBranchRefId;
   }
 
   @Override

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
@@ -69,6 +69,19 @@ public class BitBucketPPRHookJobDslContext implements Context {
     triggers.add(repositoryTriggerFilter);
   }
 
+  public void repositoryPushAction(boolean triggerAlsoIfTagPush,
+      boolean triggerAlsoIfNothingChanged, String allowedBranches, boolean isToApprove,
+      boolean triggerOnlyIfTagPush) {
+    BitBucketPPRRepositoryPushActionFilter repositoryPushActionFilter =
+        new BitBucketPPRRepositoryPushActionFilter(triggerAlsoIfTagPush,
+            triggerAlsoIfNothingChanged, allowedBranches);
+    repositoryPushActionFilter.setIsToApprove(isToApprove);
+    repositoryPushActionFilter.setTriggerOnlyIfTagPush(triggerOnlyIfTagPush);
+    BitBucketPPRRepositoryTriggerFilter repositoryTriggerFilter =
+        new BitBucketPPRRepositoryTriggerFilter(repositoryPushActionFilter);
+    triggers.add(repositoryTriggerFilter);
+  }
+
   public void pullRequestApprovedAction(boolean onlyIfReviewersApproved, String allowedBranches) {
     BitBucketPPRPullRequestApprovedActionFilter pullRequestApprovedActionFilter =
         new BitBucketPPRPullRequestApprovedActionFilter(onlyIfReviewersApproved);
@@ -265,6 +278,19 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRServerRepositoryPushActionFilter(triggerAlsoIfTagPush,
             triggerAlsoIfNothingChanged, allowedBranches);
     repositoryServerPushActionFilter.setIsToApprove(isToApprove);
+    BitBucketPPRRepositoryTriggerFilter repositoryServerTriggerFilter =
+        new BitBucketPPRRepositoryTriggerFilter(repositoryServerPushActionFilter);
+    triggers.add(repositoryServerTriggerFilter);
+  }
+
+  public void repositoryServerPushAction(boolean triggerAlsoIfTagPush,
+      boolean triggerAlsoIfNothingChanged, String allowedBranches, boolean isToApprove,
+      boolean triggerOnlyIfTagPush) {
+    BitBucketPPRServerRepositoryPushActionFilter repositoryServerPushActionFilter =
+        new BitBucketPPRServerRepositoryPushActionFilter(triggerAlsoIfTagPush,
+            triggerAlsoIfNothingChanged, allowedBranches);
+    repositoryServerPushActionFilter.setIsToApprove(isToApprove);
+    repositoryServerPushActionFilter.setTriggerOnlyIfTagPush(triggerOnlyIfTagPush);
     BitBucketPPRRepositoryTriggerFilter repositoryServerTriggerFilter =
         new BitBucketPPRRepositoryTriggerFilter(repositoryServerPushActionFilter);
     triggers.add(repositoryServerTriggerFilter);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -39,6 +39,7 @@ public class BitBucketPPRRepositoryPushActionFilter extends BitBucketPPRReposito
 
   public boolean triggerAlsoIfTagPush;
   public boolean triggerAlsoIfNothingChanged;
+  public boolean triggerOnlyIfTagPush;
   public String allowedBranches;
   public boolean isToApprove;
 
@@ -48,6 +49,11 @@ public class BitBucketPPRRepositoryPushActionFilter extends BitBucketPPRReposito
     this.triggerAlsoIfTagPush = triggerAlsoIfTagPush;
     this.triggerAlsoIfNothingChanged = triggerAlsoIfNothingChanged;
     this.allowedBranches = allowedBranches;
+  }
+
+  @DataBoundSetter
+  public void setTriggerOnlyIfTagPush(boolean triggerOnlyIfTagPush) {
+    this.triggerOnlyIfTagPush = triggerOnlyIfTagPush;
   }
 
   @DataBoundSetter
@@ -62,12 +68,18 @@ public class BitBucketPPRRepositoryPushActionFilter extends BitBucketPPRReposito
 
     if (!bitbucketAction.getType().equalsIgnoreCase("BRANCH")
         && !bitbucketAction.getType().equalsIgnoreCase("named_branch")
-        && !bitbucketAction.getType().equalsIgnoreCase("UPDATE") && !this.triggerAlsoIfTagPush) {
+        && !bitbucketAction.getType().equalsIgnoreCase("UPDATE")
+        && !bitbucketAction.getType().equalsIgnoreCase("TAG")
+        && !this.triggerAlsoIfTagPush) {
       logger.info(
           "Neither bitbucketAction type is BRANCH, nor UPDATE, nor trigger on tag push is set: "
               + bitbucketAction.getType());
 
       return false;
+    }
+
+    if (this.triggerOnlyIfTagPush && !bitbucketAction.getType().equalsIgnoreCase("TAG")) {
+        return false;
     }
 
     return matches(allowedBranches, bitbucketAction.getTargetBranch(), null);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -40,6 +40,7 @@ public class BitBucketPPRServerRepositoryPushActionFilter
       Logger.getLogger(BitBucketPPRServerRepositoryPushActionFilter.class.getName());
 
   public boolean triggerAlsoIfTagPush;
+  public boolean triggerOnlyIfTagPush;
   public boolean triggerAlsoIfNothingChanged;
   public String allowedBranches;
   public boolean isToApprove;
@@ -50,6 +51,11 @@ public class BitBucketPPRServerRepositoryPushActionFilter
     this.triggerAlsoIfTagPush = triggerAlsoIfTagPush;
     this.triggerAlsoIfNothingChanged = triggerAlsoIfNothingChanged;
     this.allowedBranches = allowedBranches;
+  }
+
+  @DataBoundSetter
+  public void setTriggerOnlyIfTagPush(boolean triggerOnlyIfTagPush) {
+    this.triggerOnlyIfTagPush = triggerOnlyIfTagPush;
   }
 
   @DataBoundSetter
@@ -64,7 +70,9 @@ public class BitBucketPPRServerRepositoryPushActionFilter
 
     if (!bitbucketAction.getType().equalsIgnoreCase("BRANCH")
         && !bitbucketAction.getType().equalsIgnoreCase("named_branch")
-        && !bitbucketAction.getType().equalsIgnoreCase("UPDATE") && !this.triggerAlsoIfTagPush) {
+        && !bitbucketAction.getType().equalsIgnoreCase("UPDATE")
+        && !bitbucketAction.getType().equalsIgnoreCase("TAG")
+        && !this.triggerAlsoIfTagPush) {
           LOGGER.info(
           () -> "Neither bitbucketActionType is BRANCH, nor UPDATE, nor trigger on tag push is set for bitbucket type: "
               + bitbucketAction.getType() + ".");
@@ -72,9 +80,20 @@ public class BitBucketPPRServerRepositoryPushActionFilter
       return false;
     }
 
-    LOGGER.log(Level.FINEST, "the target branch is: {0}.", bitbucketAction.getTargetBranch());
+    if (this.triggerOnlyIfTagPush && !bitbucketAction.getType().equalsIgnoreCase("TAG")) {
+        return false;
+    }
+
+    String target = null;
+    if (bitbucketAction.getType().equalsIgnoreCase("TAG")) {
+      target = bitbucketAction.getTargetBranchRefId();
+    } else {
+      target = bitbucketAction.getTargetBranch();
+    }
+
+    LOGGER.log(Level.FINEST, "the target branch is: {0}.", target);
     LOGGER.log(Level.FINEST, "The allowed branches are: {0}.", allowedBranches);
-    return matches(allowedBranches, bitbucketAction.getTargetBranch(), null);
+    return matches(allowedBranches, target, null);
   }
 
   @Override

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter/config.jelly
@@ -7,6 +7,12 @@
         </f:checkbox>
     </f:entry>
     <f:entry>
+        <f:checkbox name="triggerOnlyIfTagPush"
+                    title="Trigger only if it is a tag push"
+                    checked="${instance.triggerOnlyIfTagPush}">
+        </f:checkbox>
+    </f:entry>
+    <f:entry>
         <f:checkbox name="triggerAlsoIfNothingChanged"
                     title="Trigger also if nothing has changed in the repo"
                     checked="${instance.triggerAlsoIfNothingChanged}">

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter/config.jelly
@@ -6,6 +6,12 @@
                     checked="${instance.triggerAlsoIfTagPush}">
         </f:checkbox>
     </f:entry>
+    <f:entry>
+        <f:checkbox name="triggerOnlyIfTagPush"
+                    title="Trigger only if it is a tag push"
+                    checked="${instance.triggerOnlyIfTagPush}">
+        </f:checkbox>
+    </f:entry>
      <f:entry>
         <f:checkbox name="triggerAlsoIfNothingChanged"
                     title="Trigger also if nothing has changed in the repo"


### PR DESCRIPTION
Adds the ability to trigger builds **only** for tag pushes.

- was necessary due to different payload for cloud on tag push
- add dsl snippets
- for server only: support matching on refId, e.g. "refs/tags/*"
- update docs

For server pushes this could be realized using an allowedBranches filter like "refs/tags/*" since @rabadin 's changes in https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/pull/120. Unfortunately, due to the different structure of cloud payloads on tag push events (there is no ref id, only tag name) we would have to implement it differently for cloud or limit the feature to Server only. With the new option, we can provide the feature for both cloud + server. 
I think it could be quite useful for jobs dedicated to deployments etc.

Resolves issue #119 