### PR TITLE
Bug/146 skipping jobs

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
@@ -116,6 +116,10 @@ public interface BitBucketPPRAction extends Action {
     return null;
   }
 
+  public default String getLatestCommit() {
+    return null;
+  }
+
   public default String getCommitLink() {
     return null;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
@@ -131,6 +131,11 @@ public class BitBucketPPRPullRequestAction extends InvisibleAction implements Bi
   }
 
   @Override
+  public String getLatestCommit() {
+    return payload.getPullRequest().getSource().getCommit().getHash();
+  }
+
+  @Override
   public String getCommitLink() {
     return payload.getPullRequest().getSource().getCommit().getLinks().getSelf().getHref();
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
@@ -169,6 +169,11 @@ public class BitBucketPPRPullRequestServerAction extends InvisibleAction impleme
   }
 
   @Override
+  public String getLatestCommit() {
+    return payload.getServerPullRequest().getFromRef().getLatestCommit();
+  }
+
+  @Override
   public String getCommitLink() {
     // returns:
     // /rest/build-status/1.0/commits/{commitId}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
@@ -110,6 +110,19 @@ public class BitBucketPPRRepositoryAction extends InvisibleAction implements Bit
   }
 
   @Override
+  public String getLatestCommit() {
+    // According to constructor `targetBranchName`, `type` and `repositoryUuid` will be set to first non-null change
+    // So lets hope it is not very destructive move to set latestCommit from first change.
+    for (BitBucketPPRChange change : payload.getPush().getChanges()) {
+      if (change.getNewChange() != null) {
+        return change.getNewChange().getTarget().getHash();
+      }
+    }
+
+    return null;
+  }
+
+  @Override
   public List<String> getCommitLinks() {
     List<BitBucketPPRChange> changes = payload.getPush().getChanges();
     List<String> links = new ArrayList<>();

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
@@ -137,6 +137,18 @@ public class BitBucketPPRServerRepositoryAction extends InvisibleAction implemen
   }
 
   @Override
+  public String getLatestCommit() {
+    // According to constructor `targetBranchName`, `type` and `targetBranchRefId` will be set to first non-null change
+    // So lets hope it is not very destructive move to set latestCommit from first change.
+    for (BitBucketPPRServerChange change : payload.getServerChanges()) {
+      if (change.getRefId() != null) {
+        return change.getToHash();
+      }
+    }
+    return null;
+  }
+
+  @Override
   public List<String> getCommitLinks() {
     // returns:
     // /rest/build-status/1.0/commits/{commitId}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
@@ -57,7 +57,7 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
 
   private void send(StandardUsernamePasswordCredentials standardCredentials, String url, String payload) {
     logger.fine("Set BB StandardUsernamePasswordCredentials for backpropagation");
-    logger.fine("Url for backpropagation" + url + " with paylaod " + payload);
+    logger.fine("Url for backpropagation " + url + " with payload " + payload);
 
     final org.apache.http.client.CredentialsProvider provider = new BasicCredentialsProvider();
     String username = standardCredentials.getUsername();

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRTarget.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRTarget.java
@@ -25,7 +25,16 @@ import java.io.Serializable;
 public class BitBucketPPRTarget implements Serializable {
   private static final long serialVersionUID = 1L;
 
+  private String hash;
   private BitBucketPPRLinks links;
+
+  public String getHash() {
+    return hash;
+  }
+
+  public void setHash(String hash) {
+    this.hash = hash;
+  }
 
   public BitBucketPPRLinks getLinks() {
     return links;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRPullRequestServerObserver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRPullRequestServerObserver.java
@@ -105,8 +105,7 @@ public class BitBucketPPRPullRequestServerObserver extends BitBucketPPRHandlerTe
 
     String payload = "{\"key\": \"" + context.getRun().getNumber() + "\", \"url\": \"" + context.getAbsoluteUrl()
         + "\", ";
-    payload += result == Result.SUCCESS ? "\"state\": \"SUCCESSFUL\""
-        : result == Result.ABORTED ? "\"state\": \"STOPPED\"" : "\"state\": \"FAILED\"";
+    payload += result == Result.SUCCESS ? "\"state\": \"SUCCESSFUL\"" : "\"state\": \"FAILED\"";
     payload += " }";
 
     callClient(url, payload);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRPushServerObserver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRPushServerObserver.java
@@ -63,8 +63,7 @@ public class BitBucketPPRPushServerObserver extends BitBucketPPRHandlerTemplate 
 
       for (String url : commitLinks) {
         String payload = "{\"key\": \"" + buildNumber + "\", \"url\": \"" + absoluteUrl + "\", ";
-        payload += result == Result.SUCCESS ? "\"state\": \"SUCCESSFUL\""
-            : result == Result.ABORTED ? "\"state\": \"STOPPED\"" : "\"state\": \"FAILED\"";
+        payload += result == Result.SUCCESS ? "\"state\": \"SUCCESSFUL\"" : "\"state\": \"FAILED\"";
         payload += " }";
 
         callClient(url, payload);


### PR DESCRIPTION
An attempt to fix bug with skipping jobs. Tested with server bitbucket instance, seems works.

Also fix bug with `STOPPED` status sent back to bitbucket server. According to [docs](https://docs.atlassian.com/bitbucket-server/rest/7.8.0/bitbucket-build-rest.html) it supports only ` SUCCESSFUL`, `FAILED` and `INPROGRESS.` states, so in case of job cancel send `FAILED` status.

Also fix a small typo :)