### PR TITLE
Feature/dsl deprecation triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ bitbucketTriggers {
 
 ## Dsl Job snippets
 
+### Valid until job-dsl plugin v1.76 (deprecated in v1.77)
+
 ```groovy
 // pullRequestCreatedAction()
 job('example-pull-request-created') {
@@ -451,6 +453,507 @@ job('example-pull-request-created-updated') {
       pullRequestCreatedAction()
       pullRequestUpdatedAction()
       pullRequestMergedAction("master")
+    }
+  }
+  scm {
+    git {
+      remote {
+          url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+      shell('echo START pull request created')
+  }
+}
+```
+
+### Valid for jod-dsl 1.77+ (and before)
+
+Note that this may require an additional script approval, the seed job failing with a message similar to:
+```
+ERROR: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (javaposse.jobdsl.dsl.jobs.WorkflowJob bitbucketTrigger script$_run_closure1$_closure5$_closure24$_closure29$_closure30$_closure31)
+```
+
+```groovy
+// pullRequestCreatedAction()
+job('example-pull-request-created') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request created')
+  }
+}
+
+// pullRequestCreatedAction() with filter on branches
+job('example-pull-request-created-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request created with filter on branches')
+  }
+}
+
+// pullRequestCreatedAction() with filter on branches
+// and eventually approve Pull Request in BB after the job is done
+job('example-pull-request-created-with-filter-on-branches-and-is-to-approve') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("master")
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request created with filter on branches')
+  }
+}
+
+// pullRequestUpdatedAction()
+job('example-pull-request-updated') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request updated')
+  }
+}
+
+// pullRequestUpdatedAction() wiht filter on branches
+job('example-pull-request-updated-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request updated with filter on branches')
+  }
+}
+
+// pullRequestUpdatedAction() wiht filter on branches
+// and eventually approve Pull Request in BB after the job is done
+job('example-pull-request-updated-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("master")
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request updated with filter on branches')
+  }
+
+
+// pullRequestApprovedAction(boolean onlyIfReviewersApproved)
+job('example-pull-request-approved') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request approved')
+  }
+}
+
+// pullRequestApprovedAction(boolean onlyIfReviewersApproved) with filter on branches
+job('example-pull-request-approved-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request approved with filter on branches')
+  }
+}
+
+
+// pullRequestApprovedAction(boolean onlyIfReviewersApproved) with filter on branches
+// and eventually approve Pull Request in BB after the job is done
+job('example-pull-request-approved-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("master")
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request approved with filter on branches')
+  }
+}
+
+// pullRequestMergedAction()
+job('example-pull-request-merged') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request merged')
+  }
+}
+
+// pullRequestMergedAction() with filter on branches
+job('example-pull-request-merged-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request merged with filter on branches')
+  }
+}
+
+// pullRequestMergedAction() with filter on branches
+// and eventually approve Pull Request in BB after the job is done
+job('example-pull-request-merged-with-filter-on-branches') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("master")
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+    shell('echo START pull request merged with filter on branches')
+  }
+}
+
+// repositoryPushAction(boolean triggerAlsoIfTagPush, boolean triggerAlsoIfNothingChanged, String allowedBranches)
+job('example-push') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRRepositoryTriggerFilter {
+              actionFilter {
+                bitBucketPPRRepositoryPushActionFilter {
+                  triggerAlsoIfTagPush(false)
+                  triggerAlsoIfNothingChanged(true)
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+      shell('echo START push')
+  }
+}
+
+
+// repositoryPushAction(boolean triggerAlsoIfTagPush, boolean triggerAlsoIfNothingChanged, String allowedBranches)
+// and eventually approve Pull Request in BB after the job is done
+job('example-push') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {// and eventually approve Pull Request in BB after the job is done
+          triggers {
+            bitBucketPPRRepositoryTriggerFilter {
+              actionFilter {
+                bitBucketPPRRepositoryPushActionFilter {
+                  triggerAlsoIfTagPush(false)
+                  triggerAlsoIfNothingChanged(true)
+                  allowedBranches("master")
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  scm {
+    git {
+      remote {
+        url("https://git.company.domain/scm/~username/telegram.git")
+      }
+    }
+  }
+  steps {
+      shell('echo START push')
+  }
+}
+
+// combination of triggers is also possible
+job('example-pull-request-created-updated') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("master")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
   scm {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
@@ -31,6 +31,7 @@ import javaposse.jobdsl.plugin.DslExtensionMethod;
 @Extension
 public class BitBucketPPRHookJobDslExtension extends ContextExtensionPoint {
 
+  @Deprecated
   @DslExtensionMethod(context = TriggerContext.class)  
   public Object bitbucketTriggers(Runnable closure) {
     BitBucketPPRHookJobDslContext context = new BitBucketPPRHookJobDslContext();

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
@@ -28,11 +28,11 @@ import javaposse.jobdsl.dsl.helpers.triggers.TriggerContext;
 import javaposse.jobdsl.plugin.ContextExtensionPoint;
 import javaposse.jobdsl.plugin.DslExtensionMethod;
 
-@Extension
+@Extension(optional = true)
 public class BitBucketPPRHookJobDslExtension extends ContextExtensionPoint {
 
   @Deprecated
-  @DslExtensionMethod(context = TriggerContext.class)  
+  @DslExtensionMethod(context = TriggerContext.class)
   public Object bitbucketTriggers(Runnable closure) {
     BitBucketPPRHookJobDslContext context = new BitBucketPPRHookJobDslContext();
     executeInContext(closure, context);

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
@@ -118,7 +118,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -144,7 +145,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -170,7 +172,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -196,7 +199,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -217,7 +221,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -238,7 +243,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -259,7 +265,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -280,7 +287,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -301,7 +309,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -322,7 +331,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -343,7 +353,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -364,7 +375,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -385,7 +397,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -406,7 +419,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -432,7 +446,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -458,7 +473,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -479,7 +495,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -505,7 +522,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -532,7 +550,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -553,7 +572,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -579,7 +599,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;
@@ -605,7 +626,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -636,7 +658,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -671,7 +694,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -706,7 +730,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job1");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     for (Trigger<?> entry : triggers.values()) {
@@ -722,7 +747,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Verify second job content */
     createdJob = (FreeStyleProject) j.getInstance().getItem("test-job2");
     /* Go through all triggers to validate DSL */
-    triggers = createdJob.getTriggers();
+    pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     dispNames.clear();
     for (Trigger<?> entry : triggers.values()) {
@@ -743,7 +769,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -778,7 +805,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -819,7 +847,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -860,7 +889,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
@@ -45,6 +45,9 @@ import javaposse.jobdsl.plugin.ExecuteDslScripts;
 import javaposse.jobdsl.plugin.RemovedJobAction;
 import hudson.triggers.TriggerDescriptor;
 import hudson.triggers.Trigger;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -67,11 +70,22 @@ public class BitBucketPPRHookJobDslExtensionTest {
     j.buildAndAssertSuccess(seedJob);
   }
 
+  private String readDslScript(String path) throws Exception {
+    String script = null;
+    try {
+        ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+        InputStream is = classloader.getResourceAsStream(path);
+        script = IOUtils.toString(is, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+        e.printStackTrace();
+    }
+    return script;
+  }
+
   @Test
-  public void testDslTriggerPushAction() throws Exception {
+  public void testDslTriggerPushActionFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { repositoryPushAction(false, false, '') } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPushActionFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -96,10 +110,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerIsToApprovePushAction() throws Exception {
+  public void testDslTriggerIsToApprovePushActionFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { repositoryPushAction(false, false, '', true) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerIsToApprovePushActionFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -123,10 +136,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRApproved() throws Exception {
+  public void testDslTriggerPRApprovedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestApprovedAction(false) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRApprovedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -150,9 +162,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRIsToApproveApproved() throws Exception {
+  public void testDslTriggerPRIsToApproveApprovedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob("freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestApprovedAction(false, '', true) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRIsToApproveApprovedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -176,10 +188,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesApproved() throws Exception {
+  public void testDslTriggerPRAllowedBranchesApprovedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestApprovedAction(false, \"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesApprovedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -198,10 +209,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCommentCreated() throws Exception {
+  public void testDslTriggerPRCommentCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentCreatedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCommentCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -220,10 +230,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesCommentCreated() throws Exception {
+  public void testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentCreatedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -242,10 +251,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCommentFilterCommentCreated() throws Exception {
+  public void testDslTriggerPRCommentFilterCommentCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentCreatedAction(\"**\", \"text\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCommentFilterCommentCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -264,10 +272,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCommentUpdated() throws Exception {
+  public void testDslTriggerPRCommentUpdatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentUpdatedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCommentUpdatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -286,10 +293,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesCommentUpdated() throws Exception {
+  public void testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentUpdatedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -308,10 +314,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCommentFilterCommentUpdated() throws Exception {
+  public void testDslTriggerPRCommentFilterCommentUpdatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentUpdatedAction(\"**\", \"text\")}}}");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCommentFilterCommentUpdatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -330,10 +335,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCommentDeleted() throws Exception {
+  public void testDslTriggerPRCommentDeletedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentDeletedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCommentDeletedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -352,10 +356,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesCommentDeleted() throws Exception {
+  public void testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCommentDeletedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -374,10 +377,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRCreated() throws Exception {
+  public void testDslTriggerPRCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCreatedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -396,10 +398,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowBranchesCreated() throws Exception {
+  public void testDslTriggerPRAllowBranchesCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCreatedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowBranchesCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -423,10 +424,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowBranchesWithApproveCreated() throws Exception {
+  public void testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCreatedAction(\"**\", true) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -450,10 +450,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRUpdated() throws Exception {
+  public void testDslTriggerPRUpdatedFreeeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestUpdatedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRUpdatedFreeeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -472,10 +471,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesUpdated() throws Exception {
+  public void testDslTriggerPRAllowedBranchesUpdatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestUpdatedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesUpdatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -499,9 +497,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesWithApproveUpdated() throws Exception {
+  public void testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob("freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestUpdatedAction(\"**\", true) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -526,10 +524,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
 
 
   @Test
-  public void testDslTriggerPRMerged() throws Exception {
+  public void testDslTriggerPRMergedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestMergedAction() } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRMergedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -548,10 +545,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesMerged() throws Exception {
+  public void testDslTriggerPRAllowedBranchesMergedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestMergedAction(\"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesMergedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -575,9 +571,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerPRAllowedBranchesWithApproveMerged() throws Exception {
+  public void testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob("freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestMergedAction(\"**\", true) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -601,10 +597,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerCreateUpdatedApprovedPRActions() throws Exception {
+  public void testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCreatedAction()\npullRequestUpdatedAction()\npullRequestApprovedAction(false) } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -633,10 +628,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActions() throws Exception {
+  public void testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job') { triggers { bitbucketTriggers { pullRequestCreatedAction(\"**\")\npullRequestUpdatedAction(\"**\")\npullRequestMergedAction(\"**\")\npullRequestApprovedAction(false, \"**\") } } }");
+    createSeedJob(readDslScript("./dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -669,16 +663,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActions() throws Exception {
+  public void testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    String seedJobDesc = "freeStyleJob('test-job') { triggers { bitbucketTriggers {\n";
-    seedJobDesc += "pullRequestCreatedAction(\"**\", true)\n";
-    seedJobDesc += "pullRequestUpdatedAction(\"**\", true)\n";
-    seedJobDesc += "pullRequestMergedAction(\"**\", true)\n";
-    seedJobDesc += "pullRequestApprovedAction(false, \"**\", true)\n";
-    seedJobDesc += "} } }";
-
-    createSeedJob(seedJobDesc);
+    createSeedJob(readDslScript("./dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -711,10 +698,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslMultipleJobsInSeed() throws Exception {
+  public void testDslMultipleJobsInSeedFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(
-        "freeStyleJob('test-job1') { triggers { bitbucketTriggers { pullRequestCreatedAction() } } };freeStyleJob('test-job2') { triggers { bitbucketTriggers { repositoryPushAction(false, false, '') } } }");
+    createSeedJob(readDslScript("./dsl/testDslMultipleJobsInSeedFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job1");
     /* Go through all triggers to validate DSL */
@@ -749,15 +735,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslServerAllPRActions() throws Exception {
-    String seedJobDesc = "freeStyleJob('test-job') { triggers { bitbucketTriggers {";
-    seedJobDesc += "pullRequestServerCreatedAction()\n";
-    seedJobDesc += "pullRequestServerUpdatedAction()\n";
-    seedJobDesc += "pullRequestServerApprovedAction(false)\n";
-    seedJobDesc += "pullRequestServerMergedAction()";
-    seedJobDesc += "} } }";
+  public void testDslServerAllPRActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(seedJobDesc);
+    createSeedJob(readDslScript("./dsl/testDslServerAllPRActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -790,16 +770,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslServerAllPRAllowedBranchesActions() throws Exception {
-    String seedJobDesc = "freeStyleJob('test-job') { triggers { bitbucketTriggers {";
-    seedJobDesc += "pullRequestServerCreatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerUpdatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerSourceUpdatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerApprovedAction(false, \"*\")\n";
-    seedJobDesc += "pullRequestServerMergedAction(\"*\")";
-    seedJobDesc += "} } }";
+  public void testDslServerAllPRAllowedBranchesActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(seedJobDesc);
+    createSeedJob(readDslScript("./dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -838,16 +811,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslServerAllPRAllowedBranchesWithApproveActions() throws Exception {
-    String seedJobDesc = "freeStyleJob('test-job') { triggers { bitbucketTriggers {";
-    seedJobDesc += "pullRequestServerCreatedAction(\"*\", true)\n";
-    seedJobDesc += "pullRequestServerUpdatedAction(\"*\", true)\n";
-    seedJobDesc += "pullRequestServerSourceUpdatedAction(\"*\", true)\n";
-    seedJobDesc += "pullRequestServerApprovedAction(false, \"*\", true)\n";
-    seedJobDesc += "pullRequestServerMergedAction(\"*\", true)";
-    seedJobDesc += "} } }";
+  public void testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(seedJobDesc);
+    createSeedJob(readDslScript("./dsl/testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
@@ -886,22 +852,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
   }
 
   @Test
-  public void testDslServerAllPRUnfilteredAndAllowedBranchesActions() throws Exception {
-    String seedJobDesc = "freeStyleJob('test-job') { triggers { bitbucketTriggers {";
-    seedJobDesc += "pullRequestServerCreatedAction()\n";
-    seedJobDesc += "pullRequestServerUpdatedAction()\n";
-    seedJobDesc += "pullRequestServerSourceUpdatedAction()\n";
-    seedJobDesc += "pullRequestServerApprovedAction(false)\n";
-    seedJobDesc += "pullRequestServerMergedAction()\n";
-
-    seedJobDesc += "pullRequestServerCreatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerUpdatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerSourceUpdatedAction(\"*\")\n";
-    seedJobDesc += "pullRequestServerApprovedAction(false, \"*\")\n";
-    seedJobDesc += "pullRequestServerMergedAction(\"*\")";
-    seedJobDesc += "} } }";
+  public void testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle() throws Exception {
     /* Create seed job which will process DSL */
-    createSeedJob(seedJobDesc);
+    createSeedJob(readDslScript("./dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy"));
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
@@ -48,6 +48,7 @@ import hudson.triggers.Trigger;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -89,7 +90,8 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     FreeStyleProject createdJob = (FreeStyleProject) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    Map<TriggerDescriptor, Trigger<?>> triggers = createdJob.getTriggers();
+    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
     boolean isToApprove = false;

--- a/src/test/resources/dsl/testDslMultipleJobsInSeedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslMultipleJobsInSeedFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job1') {
   triggers {
     bitbucketTriggers {
@@ -9,6 +10,46 @@ freeStyleJob('test-job2') {
   triggers {
     bitbucketTriggers {
       repositoryPushAction(false, false, '')
+    }
+  }
+}
+*/
+freeStyleJob('test-job1') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter  {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+freeStyleJob('test-job2') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRRepositoryTriggerFilter {
+              actionFilter {
+                bitBucketPPRRepositoryPushActionFilter {
+                  triggerAlsoIfTagPush(false)
+                  triggerAlsoIfNothingChanged(false)
+                  allowedBranches('')
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslMultipleJobsInSeedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslMultipleJobsInSeedFreeStyle.groovy
@@ -1,0 +1,14 @@
+freeStyleJob('test-job1') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction()
+    }
+  }
+}
+freeStyleJob('test-job2') {
+  triggers {
+    bitbucketTriggers {
+      repositoryPushAction(false, false, '')
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
@@ -1,0 +1,10 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestServerCreatedAction()
+      pullRequestServerUpdatedAction()
+      pullRequestServerApprovedAction(false)
+      pullRequestServerMergedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -5,6 +6,44 @@ freeStyleJob('test-job') {
       pullRequestServerUpdatedAction()
       pullRequestServerApprovedAction(false)
       pullRequestServerMergedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerCreatedActionFilter  {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerUpdatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerMergedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -6,6 +7,55 @@ freeStyleJob('test-job') {
       pullRequestServerSourceUpdatedAction("*")
       pullRequestServerApprovedAction(false, "*")
       pullRequestServerMergedAction("*")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerCreatedActionFilter  {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerUpdatedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerSourceUpdatedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerMergedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
@@ -1,0 +1,11 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestServerCreatedAction("*")
+      pullRequestServerUpdatedAction("*")
+      pullRequestServerSourceUpdatedAction("*")
+      pullRequestServerApprovedAction(false, "*")
+      pullRequestServerMergedAction("*")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -6,6 +7,60 @@ freeStyleJob('test-job') {
       pullRequestServerSourceUpdatedAction("*", true)
       pullRequestServerApprovedAction(false, "*", true)
       pullRequestServerMergedAction("*", true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerCreatedActionFilter  {
+                  allowedBranches("*")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerUpdatedActionFilter {
+                  allowedBranches("*")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerSourceUpdatedActionFilter {
+                  allowedBranches("*")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("*")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerMergedActionFilter {
+                  allowedBranches("*")
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesWithApproveActionsFreeStyle.groovy
@@ -1,0 +1,11 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestServerCreatedAction("*", true)
+      pullRequestServerUpdatedAction("*", true)
+      pullRequestServerSourceUpdatedAction("*", true)
+      pullRequestServerApprovedAction(false, "*", true)
+      pullRequestServerMergedAction("*", true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -12,6 +13,86 @@ freeStyleJob('test-job') {
       pullRequestServerSourceUpdatedAction("*")
       pullRequestServerApprovedAction(false, "*")
       pullRequestServerMergedAction("*")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerCreatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerUpdatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerSourceUpdatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerMergedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerCreatedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerUpdatedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerSourceUpdatedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("*")
+                }
+              }
+            }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerMergedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
@@ -1,0 +1,17 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestServerCreatedAction()
+      pullRequestServerUpdatedAction()
+      pullRequestServerSourceUpdatedAction()
+      pullRequestServerApprovedAction(false)
+      pullRequestServerMergedAction()
+      
+      pullRequestServerCreatedAction("*")
+      pullRequestServerUpdatedAction("*")
+      pullRequestServerSourceUpdatedAction("*")
+      pullRequestServerApprovedAction(false, "*")
+      pullRequestServerMergedAction("*")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle.groovy
@@ -1,9 +1,42 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCreatedAction()
       pullRequestUpdatedAction()
       pullRequestApprovedAction(false)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedApprovedPRActionsFreeStyle.groovy
@@ -1,0 +1,9 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction()
+      pullRequestUpdatedAction()
+      pullRequestApprovedAction(false)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle.groovy
@@ -1,0 +1,10 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction("**")
+      pullRequestUpdatedAction("**")
+      pullRequestMergedAction("**")
+      pullRequestApprovedAction(false, "**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -5,6 +6,48 @@ freeStyleJob('test-job') {
       pullRequestUpdatedAction("**")
       pullRequestMergedAction("**")
       pullRequestApprovedAction(false, "**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle.groovy
@@ -1,0 +1,10 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction("**", true)
+      pullRequestUpdatedAction("**", true)
+      pullRequestMergedAction("**", true)
+      pullRequestApprovedAction(false, "**", true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedApprovedPRAllowBranchesWithApproveActionsFreeStyle.groovy
@@ -1,3 +1,4 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
@@ -5,6 +6,52 @@ freeStyleJob('test-job') {
       pullRequestUpdatedAction("**", true)
       pullRequestMergedAction("**", true)
       pullRequestApprovedAction(false, "**", true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerIsToApprovePushActionFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerIsToApprovePushActionFreeStyle.groovy
@@ -1,7 +1,31 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       repositoryPushAction(false, false, '', true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRRepositoryTriggerFilter {
+              actionFilter {
+                bitBucketPPRRepositoryPushActionFilter  {
+                  triggerAlsoIfTagPush(false)
+                  triggerAlsoIfNothingChanged(false)
+                  allowedBranches('')
+                  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerIsToApprovePushActionFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerIsToApprovePushActionFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      repositoryPushAction(false, false, '', true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowBranchesCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowBranchesCreatedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCreatedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowBranchesCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowBranchesCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction("**", true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowBranchesWithApproveCreatedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCreatedAction("**", true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesApprovedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestApprovedAction(false, "**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesApprovedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestApprovedAction(false, "**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentCreatedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentCreatedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentCreatedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentCreatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentDeletedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentDeletedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentDeletedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentDeletedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
-      pullRequestCommentUpdatedAction("**")
+      pullRequestUpdatedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentUpdatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesCommentUpdatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentUpdatedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesMergedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestMergedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesMergedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestMergedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesUpdatedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestUpdatedAction("**")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesUpdatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestUpdatedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestMergedAction("**", true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveMergedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestMergedAction("**", true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestUpdatedAction("**", true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                  allowedBranches("**")
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesWithApproveUpdatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestUpdatedAction("**", true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRApprovedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestApprovedAction(false)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRApprovedFreeStyle.groovy
@@ -1,7 +1,28 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestApprovedAction(false)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentCreatedFreeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentCreatedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentCreatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentCreatedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRCommentDeletedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentDeletedFreeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentDeletedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentDeletedActionFilter  {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCommentDeletedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentDeletedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentDeletedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentCreatedAction("**", "text")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentCreatedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentCreatedAction("**", "text")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentCreatedActionFilter  {
+                  allowedBranches("**")
+				  commentFilter("text")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentUpdatedFreeStyle.groovy
@@ -1,7 +1,29 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentUpdatedAction("**", "text")
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentUpdatedActionFilter  {
+                  allowedBranches("**")
+				  commentFilter("text")
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentFilterCommentUpdatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentUpdatedAction("**", "text")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentUpdatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCommentUpdatedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRCommentUpdatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCommentUpdatedFreeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCommentUpdatedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCommentUpdatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCreatedFreeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestCreatedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestCreatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRCreatedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRCreatedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestCreatedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRIsToApproveApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRIsToApproveApprovedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestApprovedAction(false, '', true)
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRIsToApproveApprovedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRIsToApproveApprovedFreeStyle.groovy
@@ -1,7 +1,30 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestApprovedAction(false, '', true)
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestApprovedActionFilter {
+                  triggerOnlyIfAllReviewersApproved(false)
+                  allowedBranches('')
+				  isToApprove(true)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRMergedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestMergedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRMergedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRMergedFreeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestMergedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestMergedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRUpdatedFreeeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRUpdatedFreeeStyle.groovy
@@ -1,7 +1,27 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       pullRequestUpdatedAction()
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestUpdatedActionFilter {
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/resources/dsl/testDslTriggerPRUpdatedFreeeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRUpdatedFreeeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestUpdatedAction()
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPushActionFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPushActionFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      repositoryPushAction(false, false, '')
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPushActionFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPushActionFreeStyle.groovy
@@ -1,7 +1,30 @@
+/*
 freeStyleJob('test-job') {
   triggers {
     bitbucketTriggers {
       repositoryPushAction(false, false, '')
+    }
+  }
+}
+*/
+freeStyleJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRRepositoryTriggerFilter {
+              actionFilter {
+                bitBucketPPRRepositoryPushActionFilter {
+                  triggerAlsoIfTagPush(false)
+                  triggerAlsoIfNothingChanged(false)
+                  allowedBranches('')
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Since job-dsl plugin v1.77, `triggers{}` has been marked deprecated ([see details](https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-177)), this pull request is a proposal of how to handle it by relying solely on `properties{}`.
DSLs will become much more verbose (unit tests have been updated with new paradigm).