### PR TITLE
Feature/Silence status notification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<properties>
 		<jenkins.version>2.138.2</jenkins.version>
 		<java.level>8</java.level>
-    <powermock.version>2.0.0</powermock.version>
-    <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
+		<powermock.version>2.0.0</powermock.version>
+		<hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
 	</properties>
 
 	<name>Bitbucket Push and Pull Request Plugin</name>
@@ -35,8 +35,8 @@
 		<developer>
 			<id>cdelmonte</id>
 			<name>Christian Del Monte</name>
-    		</developer>
-    		<developer>
+		</developer>
+		<developer>
 			<id>macghriogair</id>
 			<name>Patrick Mac Gregor</name>
 		</developer>
@@ -85,6 +85,14 @@
 			<version>2.14</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>script-security</artifactId>
+			<version>1.31</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
@@ -171,10 +179,18 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.jenkins-ci.tools</groupId>
+				<artifactId>maven-hpi-plugin</artifactId>
+				<version>2.6</version>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.2.0</version>
 				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
+					<source>8</source>
+					<detectJavaApiLink>false</detectJavaApiLink>
+					<additionalOptions>-Xdoclint:none</additionalOptions>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
@@ -104,9 +104,12 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
   /**
    * Called when a POST is made.
    * 
-   * @param scmTrigger
+   * @param scmTrigger SCM Trigger
+   * @param bitbucketAction BitBucket action
+   * @param bitbucketEvent BitBucket event
+   * @param observable BitBucket observable
    * 
-   * @throws IOException
+   * @throws IOException throw IO Exception
    */
   public void onPost(BitBucketPPRHookEvent bitbucketEvent, BitBucketPPRAction bitbucketAction, SCM scmTrigger,
       BitBucketPPRObservable observable) throws Exception {
@@ -243,7 +246,10 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
   /**
    * Returns the file that records the last/current polling activity.
    * 
-   * @throws JobNotStartedException, IOException
+   * @throws JobNotStartedException Job not started exception
+   * @throws IOException IOException
+   * 
+   * @return returns log file
    */
   public File getLogFile() throws JobNotStartedException, IOException {
 
@@ -299,6 +305,10 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
 
     /**
      * Writes the annotated log to the given output.
+     * 
+     * @param out XML output
+     * 
+     * @throws Exception throws exception
      */
     public void writeLogTo(XMLOutput out) throws Exception {
       new AnnotatedLargeText<BitBucketPPRWebHookPollingAction>(getLogFile(), Charset.defaultCharset(), true, this)

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/configuration/BitBucketPPRNotifyConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/configuration/BitBucketPPRNotifyConfiguration.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * The MIT License
+ * 
+ * Copyright (C) 2020, CloudBees, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package io.jenkins.plugins.bitbucketpushandpullrequest.configuration;
+
+import java.util.logging.Logger;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class BitBucketPPRNotifyConfiguration extends GlobalConfiguration {
+
+	static final Logger logger = Logger.getLogger(BitBucketPPRNotifyConfiguration.class.getName());
+
+	/** @return the singleton instance */
+	public static BitBucketPPRNotifyConfiguration get() {
+			return ExtensionList.lookupSingleton(BitBucketPPRNotifyConfiguration.class);
+	}
+
+	private boolean notifyBitBucket;
+
+	public BitBucketPPRNotifyConfiguration() {
+			// When Jenkins is restarted, load any saved configuration from disk.
+			logger.info("Creating BitBucketPPRNotifyConfiguration...");
+			this.notifyBitBucket = true;
+			load();
+	}
+
+	/** @return the currently configured label, if any */
+	public boolean isNotifyBitBucket() {
+			return notifyBitBucket;
+	}
+
+	/**
+	 * Together with {@link #isNotifyBitBucket}, binds to entry in {@code config.jelly}.
+	 * @param notifyBitBucket the new value of this field
+	 */
+	@DataBoundSetter
+	public void setNotifyBitBucket(boolean notifyBitBucket) {
+			this.notifyBitBucket = notifyBitBucket;
+	}
+
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+			req.bindJSON(this, formData);
+			save();
+			return true;
+	}
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
@@ -1,20 +1,24 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.observer;
 
+import io.jenkins.plugins.bitbucketpushandpullrequest.configuration.BitBucketPPRNotifyConfiguration;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventType;
 
 public abstract class BitBucketPPRHandlerTemplate {
 
   public void run(BitBucketPPREventType eventType) throws Exception {
-    switch (eventType) {
-      case BUILD_STARTED:
-        setBuildStatusInProgress();
-        break;
-      case BUILD_FINISHED:
-        setBuildStatusOnFinished();
-        setApproved();
-        break;
-      default:
-        throw new Exception();
+    BitBucketPPRNotifyConfiguration config = BitBucketPPRNotifyConfiguration.get();
+    if(config.isNotifyBitBucket()) {
+      switch (eventType) {
+        case BUILD_STARTED:
+          setBuildStatusInProgress();
+          break;
+        case BUILD_FINISHED:
+          setBuildStatusOnFinished();
+          setApproved();
+          break;
+        default:
+          throw new Exception();
+      }
     }
   }
 

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/configuration/BitBucketPPRNotifyConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/configuration/BitBucketPPRNotifyConfiguration/config.jelly
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:section title="${%BitBucket Push and Pull Request}">
+        <f:entry title="${%Send build status to BitBucket}" field="notifyBitBucket">
+            <f:checkbox default="true" />
+        </f:entry>
+    </f:section>
+</j:jelly>


### PR DESCRIPTION
Added a new global configuration which can be used to control if this plugin should send status notifications to BitBucket.

Fix for https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/142