### PR TITLE
Add a trigger action for declined PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ bitbucketTriggers {
   pullRequestMergedAction(allowedBranches: String)
   pullRequestMergedAction(allowedBranches: String, isToApprove: String)
 
+  pullRequestDeclinedAction()
+  pullRequestDeclinedAction(allowedBranches: String)
+
   pullRequestCommentCreatedAction()
   pullRequestCommentCreatedAction(allowedBranches: String)
   pullRequestCommentCreatedAction(allowedBranches: String, commentFilter: String) // CommentFilter is java a regex expression
@@ -191,6 +194,9 @@ bitbucketTriggers {
   pullRequestServerMergedAction()
   pullRequestServerMergedAction(allowedBranches: String)
   pullRequestServerMergedAction(allowedBranches: String, isToApprove: boolean)
+
+  pullRequestServerDeclinedAction()
+  pullRequestServerDeclinedAction(allowedBranches: String)
 
   pullRequestServerCommentCreatedAction()
   pullRequestServerCommentCreatedAction(allowedBranches : String)

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestDeclinedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestDeclinedCause.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * The MIT License
+ * 
+ * Copyright (C) 2020, CloudBees, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.cause.pullrequest.cloud;
+
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class BitBucketPPRPullRequestDeclinedCause extends BitBucketPPRPullRequestCause {
+  public BitBucketPPRPullRequestDeclinedCause(File pollingLog, BitBucketPPRAction bitbucketAction, BitBucketPPRHookEvent bitBucketEvent)
+      throws IOException {
+    super(pollingLog, bitbucketAction, bitBucketEvent);
+  }
+
+  @Override
+  public String getShortDescription() {
+    String pusher = bitbucketAction.getUser() != null ? bitbucketAction.getUser() : "";
+    return "Started by user " + pusher + ": Bitbucket PPR: pull request declined";
+  }
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerDeclinedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerDeclinedCause.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.cause.pullrequest.server;
+
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class BitBucketPPRPullRequestServerDeclinedCause extends BitBucketPPRPullRequestServerCause {
+  public BitBucketPPRPullRequestServerDeclinedCause(File pollingLog,
+                                                    BitBucketPPRAction bitbucketAction, BitBucketPPRHookEvent bitBucketEvent) throws IOException {
+    super(pollingLog, bitbucketAction, bitBucketEvent);
+  }
+
+  @Override
+  public String getShortDescription() {
+    String pusher = bitbucketAction.getUser() != null ? bitbucketAction.getUser() : "";
+    return "Started by user " + pusher + ": Bitbucket PPR: pull request declined";
+  }
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
@@ -30,12 +30,14 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.B
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestCommentDeletedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestCommentUpdatedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestCreatedActionFilter;
+import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestDeclinedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestMergedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestTriggerFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud.BitBucketPPRPullRequestUpdatedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerApprovedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerCommentCreatedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerCreatedActionFilter;
+import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerDeclinedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerMergedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerSourceUpdatedActionFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server.BitBucketPPRPullRequestServerTriggerFilter;
@@ -188,6 +190,23 @@ public class BitBucketPPRHookJobDslContext implements Context {
     pullRequestMergedActionFilter.setIsToApprove(isToApprove);
     BitBucketPPRPullRequestTriggerFilter pullRequestTriggerFilter =
         new BitBucketPPRPullRequestTriggerFilter(pullRequestMergedActionFilter);
+    triggers.add(pullRequestTriggerFilter);
+  }
+
+  public void pullRequestDeclinedAction() {
+    BitBucketPPRPullRequestDeclinedActionFilter pullRequestDeclinedActionFilter =
+            new BitBucketPPRPullRequestDeclinedActionFilter();
+    BitBucketPPRPullRequestTriggerFilter pullRequestTriggerFilter =
+            new BitBucketPPRPullRequestTriggerFilter(pullRequestDeclinedActionFilter);
+    triggers.add(pullRequestTriggerFilter);
+  }
+
+  public void pullRequestDeclinedAction(String allowedBranches) {
+    BitBucketPPRPullRequestDeclinedActionFilter pullRequestDeclinedActionFilter =
+            new BitBucketPPRPullRequestDeclinedActionFilter();
+    pullRequestDeclinedActionFilter.setAllowedBranches(allowedBranches);
+    BitBucketPPRPullRequestTriggerFilter pullRequestTriggerFilter =
+            new BitBucketPPRPullRequestTriggerFilter(pullRequestDeclinedActionFilter);
     triggers.add(pullRequestTriggerFilter);
   }
 
@@ -415,21 +434,38 @@ public class BitBucketPPRHookJobDslContext implements Context {
   }
 
   public void pullRequestServerMergedAction(String allowedBranches) {
-    BitBucketPPRPullRequestServerMergedActionFilter pullRequestServerMegedActionFilter =
+    BitBucketPPRPullRequestServerMergedActionFilter pullRequestServerMergedActionFilter =
         new BitBucketPPRPullRequestServerMergedActionFilter();
-    pullRequestServerMegedActionFilter.setAllowedBranches(allowedBranches);
+    pullRequestServerMergedActionFilter.setAllowedBranches(allowedBranches);
     BitBucketPPRPullRequestServerTriggerFilter pullRequestServerTriggerFilter =
-        new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerMegedActionFilter);
+        new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerMergedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
 
   public void pullRequestServerMergedAction(String allowedBranches, boolean isToApprove) {
-    BitBucketPPRPullRequestServerMergedActionFilter pullRequestServerMegedActionFilter =
+    BitBucketPPRPullRequestServerMergedActionFilter pullRequestServerMergedActionFilter =
         new BitBucketPPRPullRequestServerMergedActionFilter();
-    pullRequestServerMegedActionFilter.setAllowedBranches(allowedBranches);
-    pullRequestServerMegedActionFilter.setIsToApprove(isToApprove);
+    pullRequestServerMergedActionFilter.setAllowedBranches(allowedBranches);
+    pullRequestServerMergedActionFilter.setIsToApprove(isToApprove);
     BitBucketPPRPullRequestServerTriggerFilter pullRequestServerTriggerFilter =
-        new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerMegedActionFilter);
+        new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerMergedActionFilter);
+    triggers.add(pullRequestServerTriggerFilter);
+  }
+
+  public void pullRequestServerDeclinedAction() {
+    BitBucketPPRPullRequestServerDeclinedActionFilter pullRequestServerDeclinedActionFilter =
+            new BitBucketPPRPullRequestServerDeclinedActionFilter();
+    BitBucketPPRPullRequestServerTriggerFilter pullRequestServerTriggerFilter =
+            new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerDeclinedActionFilter);
+    triggers.add(pullRequestServerTriggerFilter);
+  }
+
+  public void pullRequestServerDeclinedAction(String allowedBranches) {
+    BitBucketPPRPullRequestServerDeclinedActionFilter pullRequestServerDeclinedActionFilter =
+            new BitBucketPPRPullRequestServerDeclinedActionFilter();
+    pullRequestServerDeclinedActionFilter.setAllowedBranches(allowedBranches);
+    BitBucketPPRPullRequestServerTriggerFilter pullRequestServerTriggerFilter =
+            new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerDeclinedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
 
@@ -459,4 +495,5 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerCommentCreatedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
+
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * The MIT License
+ * 
+ * Copyright (C) 2019, CloudBees, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
+
+import hudson.Extension;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
+import io.jenkins.plugins.bitbucketpushandpullrequest.cause.pullrequest.cloud.BitBucketPPRPullRequestDeclinedCause;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.File;
+import java.io.IOException;
+
+public class BitBucketPPRPullRequestDeclinedActionFilter extends BitBucketPPRPullRequestActionFilter {
+  public String allowedBranches;
+
+  @DataBoundConstructor
+  public BitBucketPPRPullRequestDeclinedActionFilter() {}
+  
+  @DataBoundSetter
+  public void setAllowedBranches(String allowedBranches) {
+    if (allowedBranches == null) {
+      this.allowedBranches = "";
+    } else {
+      this.allowedBranches = allowedBranches;
+    }
+  }
+
+  @Override
+  public boolean shouldTriggerBuild(BitBucketPPRAction bitbucketAction) {
+    return matches(allowedBranches, bitbucketAction.getTargetBranch(), null);
+  }
+
+  @Override
+  public BitBucketPPRTriggerCause getCause(File pollingLog, BitBucketPPRAction pullRequestAction, 
+      BitBucketPPRHookEvent bitBucketEvent)
+      throws IOException {
+    return new BitBucketPPRPullRequestDeclinedCause(pollingLog, pullRequestAction, bitBucketEvent);
+  }
+
+  @Override
+  public boolean shouldSendApprove() {
+    return false;
+  }
+
+  @Extension
+  public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
+
+    @Override
+    public String getDisplayName() {
+      return "Declined";
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "BitBucketPPRPullRequestDeclinedActionFilter [getDescriptor()=" + getDescriptor()
+        + ", getClass()=" + getClass() + ", hashCode()=" + hashCode() + ", toString()="
+        + super.toString() + "]";
+  }
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerMatcher.java
@@ -24,6 +24,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_APPROVED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_CREATED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_DECLINED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_MERGED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_UPDATED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_COMMENT_CREATED;
@@ -52,6 +53,8 @@ public class BitBucketPPRPullRequestTriggerMatcher implements BitBucketPPREventT
         || PULL_REQUEST_COMMENT_DELETED.equals(bitbucketEvent.getAction()) && triggerFilter
             .getActionFilter() instanceof BitBucketPPRPullRequestCommentDeletedActionFilter
         || PULL_REQUEST_MERGED.equals(bitbucketEvent.getAction())
-            && triggerFilter.getActionFilter() instanceof BitBucketPPRPullRequestMergedActionFilter;
+            && triggerFilter.getActionFilter() instanceof BitBucketPPRPullRequestMergedActionFilter
+        || PULL_REQUEST_DECLINED.equals(bitbucketEvent.getAction())
+            && triggerFilter.getActionFilter() instanceof BitBucketPPRPullRequestDeclinedActionFilter;
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * The MIT License
+ * 
+ * Copyright (C) 2019, CloudBees, Inc.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server;
+
+import hudson.Extension;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
+import io.jenkins.plugins.bitbucketpushandpullrequest.cause.pullrequest.server.BitBucketPPRPullRequestServerDeclinedCause;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class BitBucketPPRPullRequestServerDeclinedActionFilter
+    extends BitBucketPPRPullRequestServerActionFilter {
+
+  public String allowedBranches;
+
+  @DataBoundConstructor
+  public BitBucketPPRPullRequestServerDeclinedActionFilter() {}
+
+  @DataBoundSetter
+  public void setAllowedBranches(String allowedBranches) {
+    if (allowedBranches == null) {
+      this.allowedBranches = "";
+    } else {
+      this.allowedBranches = allowedBranches;
+    }
+  }
+
+  @Override
+  public boolean shouldTriggerBuild(BitBucketPPRAction bitbucketAction) {
+    return matches(allowedBranches, bitbucketAction.getTargetBranch(), null)
+        || matches(allowedBranches, bitbucketAction.getTargetBranchRefId(), null);
+  }
+
+  @Override
+  public BitBucketPPRTriggerCause getCause(File pollingLog, BitBucketPPRAction pullRequestAction, 
+      BitBucketPPRHookEvent bitBucketEvent)
+      throws IOException {
+    return new BitBucketPPRPullRequestServerDeclinedCause(pollingLog, pullRequestAction, bitBucketEvent);
+  }
+
+  @Extension
+  public static class ActionFilterDescriptorImpl
+      extends BitBucketPPRPullRequestServerActionDescriptor {
+
+    @Override
+    public String getDisplayName() {
+      return "Declined";
+    }
+  }
+
+  @Override
+  public boolean shouldSendApprove() {
+    return false;
+  }
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerTriggerMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerTriggerMatcher.java
@@ -25,6 +25,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_APPROVED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_COMMENT_CREATED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_CREATED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_DECLINED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_MERGED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_UPDATED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_SOURCE_UPDATED;
@@ -54,6 +55,8 @@ public class BitBucketPPRPullRequestServerTriggerMatcher
                 .getActionFilter() instanceof BitBucketPPRPullRequestServerCreatedActionFilter)
         || (PULL_REQUEST_SERVER_MERGED.equalsIgnoreCase(bitbucketEvent.getAction()) && triggerFilter
             .getActionFilter() instanceof BitBucketPPRPullRequestServerMergedActionFilter)
+        || (PULL_REQUEST_SERVER_DECLINED.equalsIgnoreCase(bitbucketEvent.getAction()) && triggerFilter
+            .getActionFilter() instanceof BitBucketPPRPullRequestServerDeclinedActionFilter)
         || (PULL_REQUEST_SERVER_COMMENT_CREATED.equals(bitbucketEvent.getAction()) && triggerFilter
             .getActionFilter() instanceof BitBucketPPRPullRequestServerCommentCreatedActionFilter);
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
@@ -20,6 +20,8 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model;
 
+import javax.naming.OperationNotSupportedException;
+
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.DIAGNOSTICS;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PING;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_APPROVED;
@@ -28,6 +30,7 @@ import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRCo
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_MERGED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_APPROVED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_CREATED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_DECLINED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_EVENT;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_MERGED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_UPDATED;
@@ -41,7 +44,7 @@ import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRCo
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.REPOSITORY_POST;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.REPOSITORY_CLOUD_PUSH;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.REPOSITORY_SERVER_PUSH;
-import javax.naming.OperationNotSupportedException;
+
 
 
 public class BitBucketPPRHookEvent {
@@ -90,6 +93,7 @@ public class BitBucketPPRHookEvent {
           || PULL_REQUEST_SERVER_SOURCE_UPDATED.equalsIgnoreCase(action)
           || PULL_REQUEST_SERVER_APPROVED.equalsIgnoreCase(action)
           || PULL_REQUEST_SERVER_MERGED.equalsIgnoreCase(action)
+          || PULL_REQUEST_SERVER_DECLINED.equalsIgnoreCase(action)
           || PULL_REQUEST_SERVER_COMMENT_CREATED.equalsIgnoreCase(action))) {
         error = true;
       }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
@@ -27,6 +27,7 @@ import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRCo
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_APPROVED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_CREATED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_CLOUD_EVENT;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_DECLINED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_MERGED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_APPROVED;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.util.BitBucketPPRConstsUtils.PULL_REQUEST_SERVER_CREATED;
@@ -85,6 +86,7 @@ public class BitBucketPPRHookEvent {
           || PULL_REQUEST_CREATED.equalsIgnoreCase(action)
           || PULL_REQUEST_UPDATED.equalsIgnoreCase(action)
           || PULL_REQUEST_MERGED.equalsIgnoreCase(action)
+          || PULL_REQUEST_DECLINED.equalsIgnoreCase(action)
           || PULL_REQUEST_COMMENT_CREATED.equalsIgnoreCase(action)
           || PULL_REQUEST_COMMENT_UPDATED.equalsIgnoreCase(action)
           || PULL_REQUEST_COMMENT_DELETED.equalsIgnoreCase(action)

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/util/BitBucketPPRConstsUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/util/BitBucketPPRConstsUtils.java
@@ -48,6 +48,7 @@ public final class BitBucketPPRConstsUtils {
   public static final String PULL_REQUEST_SERVER_UPDATED = "modified";
   public static final String PULL_REQUEST_SERVER_SOURCE_UPDATED = "from_ref_updated";
   public static final String PULL_REQUEST_SERVER_MERGED = "merged";
+  public static final String PULL_REQUEST_SERVER_DECLINED = "declined";
   public static final String PULL_REQUEST_SERVER_COMMENT_CREATED = "comment:added";
 
   public static final String PULL_REQUEST_REVIEWER = "REVIEWER";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/util/BitBucketPPRConstsUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/util/BitBucketPPRConstsUtils.java
@@ -38,6 +38,7 @@ public final class BitBucketPPRConstsUtils {
   public static final String PULL_REQUEST_APPROVED = "approved";
   public static final String PULL_REQUEST_UPDATED = "updated";
   public static final String PULL_REQUEST_MERGED = "fulfilled";
+  public static final String PULL_REQUEST_DECLINED = "rejected";
   public static final String PULL_REQUEST_COMMENT_CREATED = "comment_created";
   public static final String PULL_REQUEST_COMMENT_UPDATED = "comment_updated";
   public static final String PULL_REQUEST_COMMENT_DELETED = "comment_deleted";

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:entry title="Allowed Branches" field="allowed">
+  		<f:textbox field="allowedBranches" />
+	  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter/help-allowed.html
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter/help-allowed.html
@@ -1,0 +1,95 @@
+<div>
+  <p>Specify the branches if you'd like to track a specific branch in a repository.
+  If left blank, all branches will be examined for changes and built.</p>
+
+  <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch
+  is unambiguous.</p>
+
+  <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented
+  with a full path the plugin will only use the part of the string right of the last slash.
+  Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+
+  <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>),
+  you'll need to specify the origin repository in the branch names to
+  make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+
+  <p>Possible options:
+    <ul>
+      <li> <strong><code>&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
+           the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br/>
+           E.g. <code>master</code>, <code>feature1</code>, ...
+      </li>
+      <li> <strong><code>refs/heads/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...
+      </li>
+      <li> <strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
+           the expected one.<br/>
+           Better use <code>refs/heads/&lt;branchName&gt;</code>.<br/>
+           E.g. <code>origin/master</code>
+      </li>
+      <li> <strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>remotes/origin/master</code>
+      </li>
+      <li> <strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>refs/remotes/origin/master</code>
+      </li>
+      <li> <strong><code>&lt;tagName&gt;</code></strong><br/>
+           This does not work since the tag will not be recognized as tag.<br/>
+           Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br/>
+           E.g. <code>git-2.3.0</code>
+      </li>
+      <li> <strong><code>refs/tags/&lt;tagName&gt;</code></strong><br/>
+           Tracks/checks out the specified tag.<br/>
+           E.g. <code>refs/tags/git-2.3.0</code>
+      </li>
+      <li> <strong><code>&lt;commitId&gt;</code></strong><br/>
+           Checks out the specified commit.<br/>
+           E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...
+      </li>
+      <li> <strong><code>${ENV_VARIABLE}</code></strong><br/>
+           It is also possible to use environment variables. In this case the variables are evaluated and the
+           result is used as described above.<br/>
+           E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...
+      </li>
+      <li> <strong><code>&lt;Wildcards&gt;</code></strong><br/>
+           The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>.
+           In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard,
+           and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would
+           match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would
+           match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.
+      </li>
+      <li> <strong><code>:&lt;regular expression&gt;</code></strong><br/>
+           The syntax is of the form: <code>:regexp</code>.
+           Regular expression syntax in branches to build will only
+           build those branches whose names match the regular
+           expression.<br/>
+           Examples:<br/>
+            <ul>
+                <li><code>:^(?!(origin/prefix)).*</code>
+                  <ul>
+                    <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+                    <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+                  </ul>
+                </li>
+                <li><code>:origin/release-\d{8}</code>
+                  <ul>
+                    <li>matches: <code>origin/release-20150101</code></li>
+                    <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+                  </ul>
+                </li>
+                <li><code>:^(?!origin/master$|origin/develop$).*</code>
+                  <ul>
+                    <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+                    <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+                  </ul>
+                </li>
+            </ul>
+      </li>
+    </ul>
+  </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:entry title="Allowed Branches" field="allowed">
+  		<f:textbox field="allowedBranches" />
+	  </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter/help-allowed.html
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter/help-allowed.html
@@ -1,0 +1,95 @@
+<div>
+  <p>Specify the branches if you'd like to track a specific branch in a repository.
+  If left blank, all branches will be examined for changes and built.</p>
+
+  <p>The safest way is to use the <code>refs/heads/&lt;branchName&gt;</code> syntax. This way the expected branch
+  is unambiguous.</p>
+
+  <p>If your branch name has a <code>/</code> in it make sure to use the full reference above. When not presented
+  with a full path the plugin will only use the part of the string right of the last slash.
+  Meaning <code>foo/bar</code> will actually match <code>bar</code>.</p>
+
+  <p>If you use a wildcard branch specifier, with a slash (e.g. <code>release/</code>),
+  you'll need to specify the origin repository in the branch names to
+  make sure changes are picked up. So e.g. <code>origin/release/</code></p>
+
+  <p>Possible options:
+    <ul>
+      <li> <strong><code>&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
+           the expected one. Better use <code>refs/heads/&lt;branchName&gt;</code>.<br/>
+           E.g. <code>master</code>, <code>feature1</code>, ...
+      </li>
+      <li> <strong><code>refs/heads/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>refs/heads/master</code>, <code>refs/heads/feature1/master</code>, ...
+      </li>
+      <li> <strong><code>&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch. If ambiguous the first result is taken, which is not necessarily
+           the expected one.<br/>
+           Better use <code>refs/heads/&lt;branchName&gt;</code>.<br/>
+           E.g. <code>origin/master</code>
+      </li>
+      <li> <strong><code>remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>remotes/origin/master</code>
+      </li>
+      <li> <strong><code>refs/remotes/&lt;remoteRepoName&gt;/&lt;branchName&gt;</code></strong><br/>
+           Tracks/checks out the specified branch.<br/>
+           E.g. <code>refs/remotes/origin/master</code>
+      </li>
+      <li> <strong><code>&lt;tagName&gt;</code></strong><br/>
+           This does not work since the tag will not be recognized as tag.<br/>
+           Use <code>refs/tags/&lt;tagName&gt;</code> instead.<br/>
+           E.g. <code>git-2.3.0</code>
+      </li>
+      <li> <strong><code>refs/tags/&lt;tagName&gt;</code></strong><br/>
+           Tracks/checks out the specified tag.<br/>
+           E.g. <code>refs/tags/git-2.3.0</code>
+      </li>
+      <li> <strong><code>&lt;commitId&gt;</code></strong><br/>
+           Checks out the specified commit.<br/>
+           E.g. <code>5062ac843f2b947733e6a3b105977056821bd352</code>, <code>5062ac84</code>, ...
+      </li>
+      <li> <strong><code>${ENV_VARIABLE}</code></strong><br/>
+           It is also possible to use environment variables. In this case the variables are evaluated and the
+           result is used as described above.<br/>
+           E.g. <code>${TREEISH}</code>, <code>refs/tags/${TAGNAME}</code>, ...
+      </li>
+      <li> <strong><code>&lt;Wildcards&gt;</code></strong><br/>
+           The syntax is of the form: <code>REPOSITORYNAME/BRANCH</code>.
+           In addition, <code>BRANCH</code> is recognized as a shorthand of <code>*/BRANCH</code>, '*' is recognized as a wildcard,
+           and '**' is recognized as wildcard that includes the separator '/'. Therefore, <code>origin/branches*</code> would
+           match <code>origin/branches-foo</code> but not <code>origin/branches/foo</code>, while <code>origin/branches**</code> would
+           match both <code>origin/branches-foo</code> and <code>origin/branches/foo</code>.
+      </li>
+      <li> <strong><code>:&lt;regular expression&gt;</code></strong><br/>
+           The syntax is of the form: <code>:regexp</code>.
+           Regular expression syntax in branches to build will only
+           build those branches whose names match the regular
+           expression.<br/>
+           Examples:<br/>
+            <ul>
+                <li><code>:^(?!(origin/prefix)).*</code>
+                  <ul>
+                    <li>matches: <code>origin</code> or <code>origin/master</code> or <code>origin/feature</code></li>
+                    <li>does not match: <code>origin/prefix</code> or <code>origin/prefix_123</code> or <code>origin/prefix-abc</code></li>
+                  </ul>
+                </li>
+                <li><code>:origin/release-\d{8}</code>
+                  <ul>
+                    <li>matches: <code>origin/release-20150101</code></li>
+                    <li>does not match: <code>origin/release-2015010</code> or <code>origin/release-201501011</code> or <code>origin/release-20150101-something</code></li>
+                  </ul>
+                </li>
+                <li><code>:^(?!origin/master$|origin/develop$).*</code>
+                  <ul>
+                    <li>matches: <code>origin/branch1</code> or <code>origin/branch-2</code> or <code>origin/master123</code> or <code>origin/develop-123</code></li>
+                    <li>does not match: <code>origin/master</code> or <code>origin/develop</code></li>
+                  </ul>
+                </li>
+            </ul>
+      </li>
+    </ul>
+  </p>
+</div>

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
@@ -152,6 +152,32 @@ public class BitBucketPPREnvironmentContributorTest {
   }
 
   @Test
+  public void buildEnvironmentForCloudPullRequestDecliedTest() {
+    BitBucketPPRPayload payload = getCloudPayload("./cloud/pr_rejected.json");
+
+    BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
+    when(cause.getPullRequestPayLoad()).thenReturn(new BitBucketPPRPullRequestAction(payload));
+    when(cause.getHookEvent()).thenReturn("X-EVENT");
+
+    // do
+    runEnvironmentContributorForCause(cause);
+
+    // assert
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_SOURCE_BRANCH, "feature/do-not-merge"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_TARGET_BRANCH, "develop"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_LINK,
+            "https://bitbucket.org/some-repo-namespace/some-repo/pull-requests/198"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_ID, "198"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_ACTOR, "me-nickname"));
+    assertThat(envVars,
+            hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_TITLE, "I have to push the pram a lot X."));
+    assertThat(envVars,
+            hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_DESCRIPTION, "Some description for PR"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PAYLOAD, payload.toString()));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_X_EVENT, "X-EVENT"));
+  }
+
+  @Test
   public void buildEnvironmentForCloudPullRequestUpdatedTest() {
     BitBucketPPRPayload payload = getCloudPayload("./cloud/pr_updated.json");
 
@@ -344,6 +370,30 @@ public class BitBucketPPREnvironmentContributorTest {
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_ID, "61"));
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_ACTOR, "me-name"));
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_TITLE, "test"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_DESCRIPTION, ""));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PAYLOAD, payload.toString()));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_X_EVENT, "X-EVENT"));
+  }
+
+  @Test
+  public void buildEnvironmentForServerPullRequestDeclinedTest() {
+    BitBucketPPRServerPayload payload = getServerPayload("./server/pr_declined.json");
+
+    BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
+    when(cause.getPullRequestPayLoad()).thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+    when(cause.getHookEvent()).thenReturn("X-EVENT");
+
+    // do
+    runEnvironmentContributorForCause(cause);
+
+    // assert
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_SOURCE_BRANCH, "bugfix/tst-2"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_TARGET_BRANCH, "master"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_LINK,
+            "http://bitbucket:7990/projects/PPRPLUG/repos/hellophp/pull-requests/7"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_ID, "7"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_ACTOR, "me-name"));
+    assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_TITLE, "dummy change"));
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PULL_REQUEST_DESCRIPTION, ""));
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_PAYLOAD, payload.toString()));
     assertThat(envVars, hasEntry(BitBucketPPREnvironmentContributor.BITBUCKET_X_EVENT, "X-EVENT"));

--- a/src/test/resources/cloud/pr_rejected.json
+++ b/src/test/resources/cloud/pr_rejected.json
@@ -1,0 +1,295 @@
+{
+  "approval": {
+    "date": "2020-02-10T16:28:37.177914+00:00",
+    "user": {
+      "display_name": "me display name",
+      "account_id": "3d5b55f1ac85d1235d0734ea",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A/"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/3d5b55f1ac85d1235d0734ea?d=https%3A%2F%2Fexample-org%2Fsome-avatar.png"
+        }
+      },
+      "nickname": "me-nickname",
+      "type": "user",
+      "uuid": "{12345d55a-gef5-223e-g047-2ae1f238g70e}"
+    }
+  },
+  "pullrequest": {
+    "rendered": {
+      "description": {
+        "raw": "",
+        "markup": "markdown",
+        "html": "",
+        "type": "rendered"
+      },
+      "title": {
+        "raw": "I have to push the pram a lot.",
+        "markup": "markdown",
+        "html": "<p>I have to push the pram a lot.</p>",
+        "type": "rendered"
+      }
+    },
+    "type": "pullrequest",
+    "description": "Some description for PR",
+    "links": {
+      "decline": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/decline"
+      },
+      "diffstat": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/diffstat/some-repo-namespace/some-repo:123ea256a4ga%1Ea543d461dabc?from_pullrequest_id=198"
+      },
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/commits"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/comments"
+      },
+      "merge": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/merge"
+      },
+      "html": {
+        "href": "https://bitbucket.org/some-repo-namespace/some-repo/pull-requests/198"
+      },
+      "activity": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/activity"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/diff/some-repo-namespace/some-repo:123ea256a4ga%1Ea543d461dabc?from_pullrequest_id=198"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/pullrequests/198/statuses"
+      }
+    },
+    "title": "I have to push the pram a lot X.",
+    "close_source_branch": false,
+    "reviewers": [],
+    "id": 198,
+    "destination": {
+      "commit": {
+        "hash": "a421e461dabd",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/commit/a421e461dabd"
+          },
+          "html": {
+            "href": "https://bitbucket.org/some-repo-namespace/some-repo/commits/a421e461dabd"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo"
+          },
+          "html": {
+            "href": "https://bitbucket.org/some-repo-namespace/some-repo"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%236b5a1057-12ee-ddc1-b35e-3c136cce0cd2%1A?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "some-repo",
+        "full_name": "some-repo-namespace/some-repo",
+        "uuid": "{2c2g914f-14eg-47a3-d35e-dc334cae1db1}"
+      },
+      "branch": {
+        "name": "develop"
+      }
+    },
+    "created_on": "2020-02-10T16:28:23.479817+00:00",
+    "summary": {
+      "raw": "",
+      "markup": "markdown",
+      "html": "",
+      "type": "rendered"
+    },
+    "source": {
+      "commit": {
+        "hash": "123db174babc",
+        "type": "commit",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo/commit/123db174babc"
+          },
+          "html": {
+            "href": "https://bitbucket.org/some-repo-namespace/some-repo/commits/123db174babc"
+          }
+        }
+      },
+      "repository": {
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo"
+          },
+          "html": {
+            "href": "https://bitbucket.org/some-repo-namespace/some-repo"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%236b5a1057-12ee-ddc1-b35e-3c136cce0cd2%1A?ts=default"
+          }
+        },
+        "type": "repository",
+        "name": "some-repo",
+        "full_name": "some-repo-namespace/some-repo",
+        "uuid": "{2c2g914f-14eg-47a3-d35e-dc334cae1db1}"
+      },
+      "branch": {
+        "name": "feature/do-not-merge"
+      }
+    },
+    "comment_count": 0,
+    "state": "DECLINED",
+    "task_count": 0,
+    "participants": [
+      {
+        "role": "PARTICIPANT",
+        "participated_on": "2020-02-10T16:28:37.177914+00:00",
+        "type": "participant",
+        "user": {
+          "display_name": "me display name",
+          "account_id": "3d5b55f1ac85d1235d0734ea",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/users/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A"
+            },
+            "html": {
+              "href": "https://bitbucket.org/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A/"
+            },
+            "avatar": {
+              "href": "https://secure.gravatar.com/avatar/3d5b55f1ac85d1235d0734ea?d=https%3A%2F%2Fexample-org%2Fsome-avatar.png"
+            }
+          },
+          "nickname": "me-nickname",
+          "type": "user",
+          "uuid": "{12345d55a-gef5-223e-g047-2ae1f238g70e}"
+        },
+        "approved": true
+      }
+    ],
+    "reason": "tst reasons",
+    "updated_on": "2020-02-10T16:28:37.177914+00:00",
+    "author": {
+      "display_name": "me display name",
+      "account_id": "3d5b55f1ac85d1235d0734ea",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A/"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/3d5b55f1ac85d1235d0734ea?d=https%3A%2F%2Fexample-org%2Fsome-avatar.png"
+        }
+      },
+      "nickname": "me-nickname",
+      "type": "user",
+      "uuid": "{12345d55a-gef5-223e-g047-2ae1f238g70e}"
+    },
+    "merge_commit": null,
+    "closed_by": {
+      "display_name": "User 1",
+      "uuid": "{12345d55a-gef5-223e-g047-2ae1f238g70e}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/12345d55a-gef5-223e-g047-2ae1f238g70e"
+        },
+        "html": {
+          "href": "https://bitbucket.org/12345d55a-gef5-223e-g047-2ae1f238g70e/"
+        },
+        "avatar": {
+          "href": "https://secure.gravatar.com/avatar/blabla.png"
+        }
+      },
+      "type": "user",
+      "nickname": "me-nickname",
+      "account_id": "12345d55a-gef5-223e-g047-2ae1f238g70e"
+    }
+  },
+  "repository": {
+    "scm": "git",
+    "website": "",
+    "name": "some-repo",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/some-repo-namespace/some-repo"
+      },
+      "html": {
+        "href": "https://bitbucket.org/some-repo-namespace/some-repo"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%236b5a1057-12ee-ddc1-b35e-3c136cce0cd2%1A?ts=default"
+      }
+    },
+    "project": {
+      "key": "ABC",
+      "type": "project",
+      "uuid": "{ab123f16-dde5-203b-afe9-1ece1a3ab3de}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/some-repo-namespace/projects/ABC"
+        },
+        "html": {
+          "href": "https://bitbucket.org/account/user/some-repo-namespace/projects/ABC"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/user/some-repo-namespace/projects/ABC/avatar/99"
+        }
+      },
+      "name": "some-repo-one"
+    },
+    "full_name": "some-repo-namespace/some-repo",
+    "owner": {
+      "username": "some-repo-namespace",
+      "display_name": "some-repo-namespace-display-name",
+      "type": "team",
+      "uuid": "{a14b313f-3a59-2047-6317-bee38d215012}",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/teams/%7Ba14b313f-3a59-2047-6317-bee38d215012%7D"
+        },
+        "html": {
+          "href": "https://bitbucket.org/%7Ba14b313f-3a59-2047-6317-bee38d215012%7D/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/some-repo-namespace/avatar/"
+        }
+      }
+    },
+    "type": "repository",
+    "is_private": false,
+    "uuid": "{2c2g914f-14eg-47a3-d35e-dc334cae1db1}"
+  },
+  "actor": {
+    "display_name": "me display name",
+    "account_id": "3d5b55f1ac85d1235d0734ea",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A"
+      },
+      "html": {
+        "href": "https://bitbucket.org/%3d5b55d65c-efb5-223d-b067-2de5c338f70e%4A/"
+      },
+      "avatar": {
+        "href": "https://secure.gravatar.com/avatar/3d5b55f1ac85d1235d0734ea?d=https%3A%2F%2Fexample-org%2Fsome-avatar.png"
+      }
+    },
+    "nickname": "me-nickname",
+    "type": "user",
+    "uuid": "{12345d55a-gef5-223e-g047-2ae1f238g70e}"
+  }
+}

--- a/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRActionsFreeStyle.groovy
@@ -5,6 +5,7 @@ freeStyleJob('test-job') {
       pullRequestServerUpdatedAction()
       pullRequestServerApprovedAction(false)
       pullRequestServerMergedAction()
+      pullRequestServerDeclinedAction()
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRActionsPipeline.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRActionsPipeline.groovy
@@ -29,6 +29,12 @@ pipelineJob('test-job') {
                 }
               }
             }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerDeclinedActionFilter {
+                }
+              }
+            }
           }
         }
       }

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsFreeStyle.groovy
@@ -6,6 +6,7 @@ freeStyleJob('test-job') {
       pullRequestServerSourceUpdatedAction("*")
       pullRequestServerApprovedAction(false, "*")
       pullRequestServerMergedAction("*")
+      pullRequestServerDeclinedAction("*")
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsPipeline.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRAllowedBranchesActionsPipeline.groovy
@@ -40,6 +40,13 @@ pipelineJob('test-job') {
                 }
               }
             }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerDeclinedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
           }
         }
       }

--- a/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsFreeStyle.groovy
@@ -6,12 +6,14 @@ freeStyleJob('test-job') {
       pullRequestServerSourceUpdatedAction()
       pullRequestServerApprovedAction(false)
       pullRequestServerMergedAction()
-      
+      pullRequestServerDeclinedAction()
+
       pullRequestServerCreatedAction("*")
       pullRequestServerUpdatedAction("*")
       pullRequestServerSourceUpdatedAction("*")
       pullRequestServerApprovedAction(false, "*")
       pullRequestServerMergedAction("*")
+      pullRequestServerDeclinedAction("*")
     }
   }
 }

--- a/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsPipeline.groovy
+++ b/src/test/resources/dsl/testDslServerAllPRUnfilteredAndAllowedBranchesActionsPipeline.groovy
@@ -71,6 +71,13 @@ pipelineJob('test-job') {
                 }
               }
             }
+            bitBucketPPRPullRequestServerTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestServerDeclinedActionFilter {
+                  allowedBranches("*")
+                }
+              }
+            }
           }
         }
       }

--- a/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedDeclinedApprovedPRAllowBranchesActionsFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerCreateUpdatedMergedDeclinedApprovedPRAllowBranchesActionsFreeStyle.groovy
@@ -4,6 +4,7 @@ freeStyleJob('test-job') {
       pullRequestCreatedAction("**")
       pullRequestUpdatedAction("**")
       pullRequestMergedAction("**")
+      pullRequestDeclinedAction("**")
       pullRequestApprovedAction(false, "**")
     }
   }

--- a/src/test/resources/dsl/testDslTriggerDeclinedPRAllowBranchesPipeline.groovy
+++ b/src/test/resources/dsl/testDslTriggerDeclinedPRAllowBranchesPipeline.groovy
@@ -1,0 +1,19 @@
+pipelineJob('test-job') {
+  properties {
+    pipelineTriggers {
+      triggers {
+        bitBucketTrigger {
+          triggers {
+            bitBucketPPRPullRequestTriggerFilter {
+              actionFilter {
+                bitBucketPPRPullRequestDeclinedActionFilter {
+                  allowedBranches("**")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRAllowedBranchesDeclinedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRAllowedBranchesDeclinedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestDeclinedAction("**")
+    }
+  }
+}

--- a/src/test/resources/dsl/testDslTriggerPRDeclinedFreeStyle.groovy
+++ b/src/test/resources/dsl/testDslTriggerPRDeclinedFreeStyle.groovy
@@ -1,0 +1,7 @@
+freeStyleJob('test-job') {
+  triggers {
+    bitbucketTriggers {
+      pullRequestDeclinedAction()
+    }
+  }
+}

--- a/src/test/resources/server/pr_declined.json
+++ b/src/test/resources/server/pr_declined.json
@@ -1,0 +1,156 @@
+{
+  "eventKey": "pr:declined",
+  "date": "2021-05-29T20:18:01+0000",
+  "actor": {
+    "name": "me-name",
+    "emailAddress": "me@example.org",
+    "id": 99,
+    "displayName": "me-display-name",
+    "active": true,
+    "slug": "me-slug",
+    "type": "NORMAL",
+    "links": {
+      "self": [
+        {
+          "href": "http://bitbucket:7990/users/me-name"
+        }
+      ]
+    }
+  },
+  "pullRequest": {
+    "id": 7,
+    "version": 6,
+    "title": "dummy change",
+    "state": "DECLINED",
+    "open": false,
+    "closed": true,
+    "createdDate": 1621859343568,
+    "updatedDate": 1622319481519,
+    "closedDate": 1622319481519,
+    "fromRef": {
+      "id": "refs/heads/bugfix/tst-2",
+      "displayId": "bugfix/tst-2",
+      "latestCommit": "6efe3d09aff4bb7f53ddf2f18a6fba52aa209d1a",
+      "repository": {
+        "slug": "hellophp",
+        "id": 2,
+        "name": "hellophp",
+        "hierarchyId": "a76a391f310843fe63ec",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "PPRPLUG",
+          "id": 1,
+          "name": "ppr-plugin-test",
+          "public": false,
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "http://bitbucket:7990/projects/PPRPLUG"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "http://bitbucket:7990/scm/pprplug/hellophp.git",
+              "name": "http"
+            },
+            {
+              "href": "ssh://git@bitbucket:7999/pprplug/hellophp.git",
+              "name": "ssh"
+            }
+          ],
+          "self": [
+            {
+              "href": "http://bitbucket:7990/projects/PPRPLUG/repos/hellophp/browse"
+            }
+          ]
+        }
+      }
+    },
+    "toRef": {
+      "id": "refs/heads/master",
+      "displayId": "master",
+      "latestCommit": "047882eedc24d603a03a30e6ea16b3a607afda1b",
+      "repository": {
+        "slug": "hellophp",
+        "id": 2,
+        "name": "hellophp",
+        "hierarchyId": "a76a391f310843fe63ec",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "PPRPLUG",
+          "id": 1,
+          "name": "ppr-plugin-test",
+          "public": false,
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "http://bitbucket:7990/projects/PPRPLUG"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "links": {
+          "clone": [
+            {
+              "href": "http://bitbucket:7990/scm/pprplug/hellophp.git",
+              "name": "http"
+            },
+            {
+              "href": "ssh://git@bitbucket:7999/pprplug/hellophp.git",
+              "name": "ssh"
+            }
+          ],
+          "self": [
+            {
+              "href": "http://bitbucket:7990/projects/PPRPLUG/repos/hellophp/browse"
+            }
+          ]
+        }
+      }
+    },
+    "locked": false,
+    "author": {
+      "user": {
+        "name": "me-name",
+        "emailAddress": "me@example.org",
+        "id": 1,
+        "displayName": "me-display-name",
+        "active": true,
+        "slug": "me-slug",
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "http://bitbucket:7990/users/me-name"
+            }
+          ]
+        }
+      },
+      "role": "AUTHOR",
+      "approved": false,
+      "status": "UNAPPROVED"
+    },
+    "reviewers": [],
+    "participants": [],
+    "links": {
+      "self": [
+        {
+          "href": "http://bitbucket:7990/projects/PPRPLUG/repos/hellophp/pull-requests/7"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is my attempt to add support for triggering a job when a pull request is declined (#173)
(I took the liberty of doing this, because I tough it was a good way to get to know the code base)

Here's what I did:
- Created the appropriate new Cause classes
- Created the appropriate new ActionFilter classes
- Added the required config templates and help
- Extended the supported list of events 
   -  (BitBucketPPRHookEvent)
   - BitBucketPPRPullRequestServerTriggerMatcher and BitBucketPPRPullRequestTriggerMatcher
- Added new methods for the Job DSL + implemented unit tests similar to the existing ones
- Updated the readme
- I tested my changes with Jenkins v2.291 + Bitbucket Cloud, and Bitbucket Server v7.6.2

PR Check list:
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
