### PR TITLE
Use "get" prefix for configuration attribute getters

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
@@ -66,7 +66,7 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
     return hookUrl;
   }
 
-  public boolean shouldNotifyBitBucket() {
+  public boolean getNotifyBitBucket() {
     return notifyBitBucket;
   }
 
@@ -75,7 +75,7 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
     this.notifyBitBucket = notifyBitBucket;
   }
 
-  public boolean shouldUseJobNameAsBuildKey() {
+  public boolean getUseJobNameAsBuildKey() {
     return useJobNameAsBuildKey;
   }
 
@@ -88,6 +88,8 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   public void setCredentialsId(@CheckForNull String credentialsId) {
     this.credentialsId = credentialsId;
   }
+
+  public String getCredentialsId() { return credentialsId; }
 
   @DataBoundSetter
   public void setSingleJob(String singleJob) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
@@ -45,12 +45,12 @@ public abstract class BitBucketPPRHandlerTemplate {
     BitBucketPPRPluginConfig config = getGlobalConfig();
     switch (eventType) {
       case BUILD_STARTED:
-        if (config.shouldNotifyBitBucket()) {
+        if (config.getNotifyBitBucket()) {
           setBuildStatusInProgress();
         }
         break;
       case BUILD_FINISHED:
-        if (config.shouldNotifyBitBucket()) {
+        if (config.getNotifyBitBucket()) {
           setBuildStatusOnFinished();
           setApprovedOrDeclined();
         }
@@ -74,7 +74,7 @@ public abstract class BitBucketPPRHandlerTemplate {
   }
 
   protected String computeBitBucketBuildKey(BitBucketPPREventContext context) {
-    if (getGlobalConfig().shouldUseJobNameAsBuildKey()) {
+    if (getGlobalConfig().getUseJobNameAsBuildKey()) {
       Job<?, ?> job = context.getRun().getParent();
       return job.getDisplayName();
     } else {

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRConfigAttributesTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRConfigAttributesTest.java
@@ -1,0 +1,41 @@
+package io.jenkins.plugins.bitbucketpushandpullrequest.config;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BitBucketPPRConfigAttributesTest {
+
+  final private Class<BitBucketPPRPluginConfig> config = BitBucketPPRPluginConfig.class;
+
+  @Test
+  public void settersHaveGetters() {
+    for (Method method : config.getMethods()) {
+      final String methodName = method.getName();
+      if (method.getParameterCount() != 1 || !methodName.startsWith("set")) {
+        // Not an accessor, ignore
+        continue;
+      }
+
+      final String s = methodName.substring(3);
+      assertTrue(s, hasGetter(s));
+    }
+  }
+
+  private boolean hasGetter(String s) {
+    List<String> candidates = Arrays.asList("get" + s, "is" + s);
+    for (Method m : config.getMethods()) {
+      if (m.getParameterCount() == 0 && candidates.contains(m.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRCloudObserverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRCloudObserverTest.java
@@ -113,13 +113,13 @@ public class BitBucketPPRCloudObserverTest {
     Mockito.doReturn(config).when(spyObserver).getGlobalConfig();
 
     // When it's configured to not use the job name
-    Mockito.when(config.shouldUseJobNameAsBuildKey()).thenReturn(false);
+    Mockito.when(config.getUseJobNameAsBuildKey()).thenReturn(false);
 
     // Then the build number shall be the key
     assertEquals(String.valueOf(buildNumber), spyObserver.computeBitBucketBuildKey(context));
 
     // When it's configured to use the job name
-    Mockito.when(config.shouldUseJobNameAsBuildKey()).thenReturn(true);
+    Mockito.when(config.getUseJobNameAsBuildKey()).thenReturn(true);
 
     // Then the the job name shall be the key
     assertEquals(jobName, spyObserver.computeBitBucketBuildKey(context));
@@ -144,13 +144,13 @@ public class BitBucketPPRCloudObserverTest {
 
 
     // When it's configured to not use the job name
-    Mockito.when(config.shouldUseJobNameAsBuildKey()).thenReturn(false);
+    Mockito.when(config.getUseJobNameAsBuildKey()).thenReturn(false);
 
     // Then the build number shall be the key
     assertEquals(String.valueOf(buildNumber), spyObserver.computeBitBucketBuildKey(context));
 
     // When it's configured to use the job name
-    Mockito.when(config.shouldUseJobNameAsBuildKey()).thenReturn(true);
+    Mockito.when(config.getUseJobNameAsBuildKey()).thenReturn(true);
 
     // Then the the job name shall be the key
     assertEquals(jobName, spyObserver.computeBitBucketBuildKey(context));


### PR DESCRIPTION
The configuration-as-code plugin expects a plugins configuration attributes to be accessible with setters prefixed with "set" and getters prefixed with "get" or "is".

Change and add the getters for the configurations attributes that don't follow this convention so this plugin can be fully configured with configuration as code.

A test has been added that ensures that all configuration methods with a "set" prefix has a corresponding "get" or "is" prefix. This is similar to how the configuration as code plugin does it.

I have not created a related issue for this, but the issue is that this plugin is not fully configurable with [configuration-as-code](https://github.com/jenkinsci/configuration-as-code-plugin) which is unfortunate. I will of course create a related issue if this is required.

```[tasklist]
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
