### PR TITLE
#334 - fix log message pattern to include parameter index

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientCloudVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientCloudVisitor.java
@@ -60,7 +60,7 @@ public class BitBucketPPRClientCloudVisitor implements BitBucketPPRClientVisitor
         logger.log(Level.FINEST, "Result of the status notification is: {0}, with status code: {1}",
             new Object[] {responseBody, response.getStatusLine().getStatusCode()});
       } catch (IOException e) {
-        logger.log(Level.WARNING, "Error during state notification: {} ", e.getMessage());
+        logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
       }
     else if (credentials instanceof StringCredentials) {
       try {
@@ -69,7 +69,7 @@ public class BitBucketPPRClientCloudVisitor implements BitBucketPPRClientVisitor
         logger.log(Level.FINEST, "Result of the state notification is: {0}, with status code: {1}",
             new Object[] {response.getBody(), response.getCode()});
       } catch (ExecutionException | IOException e) {
-        logger.log(Level.WARNING, "Error during state notification: {} ", e.getMessage());
+        logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
       } catch (InterruptedException e) {
         throw e;
       }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
@@ -63,7 +63,7 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
         logger.log(Level.FINEST, "Result of the status notification is: {0}, with status code: {1}",
             new Object[] {responseBody, response.getStatusLine().getStatusCode()});
       } catch (IOException e) {
-        logger.log(Level.WARNING, "Error during state notification: {} ", e.getMessage());
+        logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
       }
     else if (credentials instanceof StringCredentials)
       try {
@@ -73,7 +73,7 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
                 response.getStatusLine().getStatusCode()});
       } catch (ExecutionException | IOException | KeyManagementException | NoSuchAlgorithmException
           | KeyStoreException e) {
-        logger.log(Level.WARNING, "Error du" + "ring state notification: {} ", e.getMessage());
+        logger.log(Level.WARNING, "Error du" + "ring state notification: {0} ", e.getMessage());
       } catch (InterruptedException e) {
         throw e;
       }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/common/BitBucketPPRUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/common/BitBucketPPRUtils.java
@@ -89,7 +89,7 @@ public class BitBucketPPRUtils {
     }
 
     if (patternStr == null || patternStr.trim().isEmpty()) {
-      logger.fine(String.format("The regex filter on the comment from BB is null or it is empty", new Object[] {}));
+      logger.fine("The regex filter on the comment from BB is null or it is empty");
       return true;
     }
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
@@ -90,7 +90,7 @@ public abstract class BitBucketPPRHandlerTemplate {
       String jsonPayload = objectMapper.writeValueAsString(payload);
       BitBucketPPRClientFactory.createClient(clientType, context).send(url, jsonPayload);
     } catch (JsonProcessingException e) {
-      logger.log(Level.WARNING, "Cannot create payload: {}", e.getMessage());
+      logger.log(Level.WARNING, "Cannot create payload: {0}", e.getMessage());
     } catch (Exception e) {
       logger.warning(e.getMessage());
     }
@@ -104,7 +104,7 @@ public abstract class BitBucketPPRHandlerTemplate {
       String jsonPayload = payload.isEmpty() ? "" : objectMapper.writeValueAsString(payload);
       BitBucketPPRClientFactory.createClient(clientType, context).send(verb, url, jsonPayload);
     } catch (JsonProcessingException e) {
-      logger.log(Level.WARNING, "Cannot create payload: {}", e.getMessage());
+      logger.log(Level.WARNING, "Cannot create payload: {0}", e.getMessage());
     } catch (Exception e) {
       logger.warning(e.getMessage());
     }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserverFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserverFactory.java
@@ -43,28 +43,28 @@ public class BitBucketPPRObserverFactory {
 
     if (REPOSITORY_EVENT.equalsIgnoreCase(bitbucketEvent.getEvent())
         && REPOSITORY_CLOUD_PUSH.equalsIgnoreCase(bitbucketEvent.getAction())) {
-      logger.log(Level.FINE, "Add BitBucketPPRPushCloudObserver for {}", bitbucketEvent);
+      logger.log(Level.FINE, "Add BitBucketPPRPushCloudObserver for {0}", bitbucketEvent);
       observable.addObserver(new BitBucketPPRPushCloudObserver());
     }
 
     if (REPOSITORY_EVENT.equalsIgnoreCase(bitbucketEvent.getEvent())
         && REPOSITORY_SERVER_PUSH.equalsIgnoreCase(bitbucketEvent.getAction())) {
-      logger.log(Level.FINE, "Add BitBucketPPRPushServerObserver for {}", bitbucketEvent);
+      logger.log(Level.FINE, "Add BitBucketPPRPushServerObserver for {0}", bitbucketEvent);
       observable.addObserver(new BitBucketPPRPushServerObserver());
     }
 
     if (PULL_REQUEST_CLOUD_EVENT.equals(bitbucketEvent.getEvent())) {
-      logger.log(Level.FINE, "Add BitBucketPPRPullRequestCloudObserver for {}", bitbucketEvent);
+      logger.log(Level.FINE, "Add BitBucketPPRPullRequestCloudObserver for {0}", bitbucketEvent);
       observable.addObserver(new BitBucketPPRPullRequestCloudObserver());
     }
 
     if (PULL_REQUEST_SERVER_EVENT.equals(bitbucketEvent.getEvent())) {
-      logger.log(Level.FINE, "Add BitBucketPPRPullRequestServerObserver for {}", bitbucketEvent);
+      logger.log(Level.FINE, "Add BitBucketPPRPullRequestServerObserver for {0}", bitbucketEvent);
       observable.addObserver(new BitBucketPPRPullRequestServerObserver());
     }
 
     if (observable.getObservers().isEmpty())
-      logger.log(Level.FINE, "No observer found for the observable of event {}", bitbucketEvent);
+      logger.log(Level.FINE, "No observer found for the observable of event {0}", bitbucketEvent);
 
     return observable;
   }


### PR DESCRIPTION
This is my fix for issue #334.
I did a string search for `{}` and fixed the relevant occurences one by one.

### Testing done
I created locally a log config to dump everything to the console and ran a few unit tests that were known to create the problematic log messages.
My `src/test/resources/logging.properties` file looked like this:
```
handlers=java.util.logging.ConsoleHandler
.level=ALL
java.util.logging.ConsoleHandler.level = ALL
java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue