### PR TITLE
Fix: Fix npe for propagation url settings

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
@@ -88,7 +88,7 @@ public class BitBucketPPRPullRequestServerAction extends BitBucketPPRActionAbstr
       }
     }
 
-    if (!globalConfig.getPropagationUrl().isEmpty()) {
+    if (globalConfig.isPropagationUrlSet()) {
       try {
         this.baseUrl = new URL(globalConfig.getPropagationUrl());
       } catch (MalformedURLException e) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
@@ -101,6 +101,10 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
     return propagationUrl;
   }
 
+  public boolean isPropagationUrlSet() {
+    return !isEmpty(propagationUrl);
+  }
+
   @DataBoundSetter
   public void setNotifyBitBucket(@CheckForNull boolean notifyBitBucket) {
     this.notifyBitBucket = notifyBitBucket;

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
@@ -21,6 +21,7 @@ public class BitBucketPPRPullRequestServerActionTest {
                 BitBucketPPRPluginConfig.class)) {
             BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
             config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
+            when(c.isPropagationUrlSet()).thenReturn(true);
             when(c.getPropagationUrl()).thenReturn("https://example.org/scm/some-namespace/some-repo.git");
 
             BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessorTest.java
@@ -76,7 +76,6 @@ public class BitBucketPPRPullRequestServerPayloadProcessorTest {
         Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
       BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
       config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
-      when(c.getPropagationUrl()).thenReturn("");
 
       BitBucketPPRJobProbe probe = mock(BitBucketPPRJobProbe.class);
 


### PR DESCRIPTION
When upgrading from older versions of the plugin the propagationUrl tag might be missing in
`io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig.xml`. Since propagationUrl's value is checked for emptiness only this might result in a NPE with error message:

`java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because the return value of "io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig.getPropagationUrl()" is null`

 This commit adds a check for null+emptiness.

The issue can be reproduced easily by deleting the propagationUrl tag from the given config file, reload and try to trigger a build via webhook.
You can then either enter a whitespace in the config field for propagationUrl and delete it afterwards or enter the line `<propagationUrl></propagationUrl>` into the config file directly. This will prevent throwing a NPE too.

### Testing done

I provided my fix, built a hpi file and installed it to a testinstance over the old `3.0.3` of the plugin.
I made sure `io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig.xml` was lacking the propagationUrl tag.
I could ensure that afterwards:
- I could trigger a build without the tag
- The functionality of the propagationUrl was still present when configured properly

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue