### PR TITLE
use merge commit for build if event is pull request fulfilled

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
@@ -33,9 +33,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRActionAbstract;
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPullRequestServerAction;
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRServerRepositoryAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.*;
 import org.apache.commons.jelly.XMLOutput;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.Symbol;
@@ -66,7 +64,6 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import hudson.util.SequentialExecutionQueue;
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventContext;
@@ -246,6 +243,8 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
             new CauseAction(cause),
             bitbucketAction,
             new RevisionParameterAction(bitbucketAction.getLatestCommit()));
+
+    logger.info(String.format("Commit passed to git: %s", bitbucketAction.getLatestCommit()));
 
     QueueTaskFuture<? extends Run<?, ?>> f =
         item != null ? (QueueTaskFuture) item.getFuture() : null;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
@@ -24,8 +24,6 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRRepositoryNotParsedException;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +31,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-import hudson.model.InvisibleAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
+
+import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_MERGED;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
@@ -59,10 +59,13 @@ public class BitBucketPPRPullRequestAction extends BitBucketPPRActionAbstract
   private final @Nonnull String repoSlug;
 
   private final @Nonnull String pullRequestId;
+  private final @Nonnull BitBucketPPRHookEvent bitbucketEvent;
 
-  public BitBucketPPRPullRequestAction(@Nonnull BitBucketPPRPayload payload) {
+  public BitBucketPPRPullRequestAction(
+      @Nonnull BitBucketPPRPayload payload, @Nonnull BitBucketPPRHookEvent event) {
     this.payload = payload;
     this.pullRequestId = payload.getPullRequest().getId();
+    this.bitbucketEvent = event;
 
     Map<String, String> workspaceRepo;
     try {
@@ -223,6 +226,9 @@ public class BitBucketPPRPullRequestAction extends BitBucketPPRActionAbstract
 
   @Override
   public String getLatestCommit() {
+    if (PULL_REQUEST_MERGED.equalsIgnoreCase(this.bitbucketEvent.getAction())) {
+      return payload.getPullRequest().getMergeCommit().getHash();
+    }
     return payload.getPullRequest().getSource().getCommit().getHash();
   }
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
-import hudson.model.InvisibleAction;
+
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud.BitBucketPPRChange;
 import java.util.stream.Collectors;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCloudPayload.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCloudPayload.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,7 +22,6 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
 import com.google.gson.annotations.SerializedName;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
-
 
 public class BitBucketPPRCloudPayload implements BitBucketPPRPayload {
   private static final long serialVersionUID = -3467640601880230847L;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
 
-
 public class BitBucketPPRPullRequest implements Serializable {
   private static final long serialVersionUID = -530740975503014281L;
   private String id;
@@ -36,6 +35,7 @@ public class BitBucketPPRPullRequest implements Serializable {
   private BitBucketPPRActor author;
   private @SerializedName("created_on") Date createdOn;
   private @SerializedName("updated_on") Date updatedOn;
+  private @SerializedName("merge_commit") BitBucketPPRCommit mergeCommit;
   private BitBucketPPRSource source;
   private BitBucketPPRDestination destination;
   private List<BitBucketPPRParticipant> participants = new ArrayList<>();
@@ -73,6 +73,14 @@ public class BitBucketPPRPullRequest implements Serializable {
 
   public void setState(final String state) {
     this.state = state;
+  }
+
+  public BitBucketPPRCommit getMergeCommit() {
+    return mergeCommit;
+  }
+
+  public void setMergeCommit(final BitBucketPPRCommit mergeCommit) {
+    this.mergeCommit = mergeCommit;
   }
 
   public BitBucketPPRActor getAuthor() {
@@ -149,9 +157,32 @@ public class BitBucketPPRPullRequest implements Serializable {
 
   @Override
   public String toString() {
-    return "BitBucketPPRPullRequest [id=" + id + ", title=" + title + ", description=" + description
-        + ", state=" + state + ", author=" + author + ", createdOn=" + createdOn + ", updatedOn="
-        + updatedOn + ", source=" + source + ", destination=" + destination + ", participants="
-        + participants + ", type=" + type + ", reason=" + reason + ", links=" + links + "]";
+    return "BitBucketPPRPullRequest [id="
+        + id
+        + ", title="
+        + title
+        + ", description="
+        + description
+        + ", state="
+        + state
+        + ", author="
+        + author
+        + ", createdOn="
+        + createdOn
+        + ", updatedOn="
+        + updatedOn
+        + ", source="
+        + source
+        + ", destination="
+        + destination
+        + ", participants="
+        + participants
+        + ", type="
+        + type
+        + ", reason="
+        + reason
+        + ", links="
+        + links
+        + "]";
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPayloadProcessor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -27,18 +27,18 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEven
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 import io.jenkins.plugins.bitbucketpushandpullrequest.observer.BitBucketPPRObservable;
 
-
 public abstract class BitBucketPPRPayloadProcessor {
   protected final BitBucketPPRJobProbe jobProbe;
   protected final BitBucketPPRHookEvent bitbucketEvent;
 
-
-  public BitBucketPPRPayloadProcessor(@Nonnull final BitBucketPPRJobProbe jobProbe,
+  public BitBucketPPRPayloadProcessor(
+      @Nonnull final BitBucketPPRJobProbe jobProbe,
       @Nonnull final BitBucketPPRHookEvent bitbucketEvent) {
     this.jobProbe = jobProbe;
     this.bitbucketEvent = bitbucketEvent;
   }
 
-  public abstract void processPayload(@Nonnull BitBucketPPRPayload payload, BitBucketPPRObservable observable)
+  public abstract void processPayload(
+      @Nonnull BitBucketPPRPayload payload, BitBucketPPRObservable observable)
       throws BitBucketPPRPayloadPropertyNotFoundException;
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestCloudPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestCloudPayloadProcessor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -28,21 +28,21 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEven
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 import io.jenkins.plugins.bitbucketpushandpullrequest.observer.BitBucketPPRObservable;
 
-
 public class BitBucketPPRPullRequestCloudPayloadProcessor extends BitBucketPPRPayloadProcessor {
-  public BitBucketPPRPullRequestCloudPayloadProcessor(@Nonnull BitBucketPPRJobProbe jobProbe,
-      @Nonnull BitBucketPPRHookEvent bitbucketEvent) {
+  public BitBucketPPRPullRequestCloudPayloadProcessor(
+      @Nonnull BitBucketPPRJobProbe jobProbe, @Nonnull BitBucketPPRHookEvent bitbucketEvent) {
     super(jobProbe, bitbucketEvent);
   }
 
-  private BitBucketPPRAction buildActionForJobs(@Nonnull BitBucketPPRPayload payload) {
-    return new BitBucketPPRPullRequestAction(payload);
+  private BitBucketPPRAction buildActionForJobs(
+      @Nonnull BitBucketPPRPayload payload, BitBucketPPRHookEvent event) {
+    return new BitBucketPPRPullRequestAction(payload, event);
   }
 
   @Override
-  public void processPayload(@Nonnull BitBucketPPRPayload payload,
-      BitBucketPPRObservable observable) {
-    BitBucketPPRAction action = buildActionForJobs(payload);
+  public void processPayload(
+      @Nonnull BitBucketPPRPayload payload, BitBucketPPRObservable observable) {
+    BitBucketPPRAction action = buildActionForJobs(payload, bitbucketEvent);
     jobProbe.triggerMatchingJobs(bitbucketEvent, action, observable);
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessor.java
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  ******************************************************************************/
 
-
 package io.jenkins.plugins.bitbucketpushandpullrequest.processor;
 
 import static java.util.Objects.nonNull;
@@ -34,28 +33,29 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.observer.BitBucketPPRObser
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
-
 public class BitBucketPPRPullRequestServerPayloadProcessor extends BitBucketPPRPayloadProcessor {
 
   private static final Logger logger =
       Logger.getLogger(BitBucketPPRPullRequestServerPayloadProcessor.class.getName());
 
-  public BitBucketPPRPullRequestServerPayloadProcessor(@Nonnull BitBucketPPRJobProbe jobProbe,
-      @Nonnull BitBucketPPRHookEvent bitbucketEvent) {
+  public BitBucketPPRPullRequestServerPayloadProcessor(
+      @Nonnull BitBucketPPRJobProbe jobProbe, @Nonnull BitBucketPPRHookEvent bitbucketEvent) {
     super(jobProbe, bitbucketEvent);
     logger.fine(() -> "Processing " + bitbucketEvent.toString());
-
   }
 
-  private BitBucketPPRAction buildActionForJobs(@Nonnull BitBucketPPRPayload payload)
+  private BitBucketPPRAction buildActionForJobs(
+      @Nonnull BitBucketPPRPayload payload, @Nonnull BitBucketPPRHookEvent bitbucketEvent)
       throws BitBucketPPRPayloadPropertyNotFoundException {
-    return new BitBucketPPRPullRequestServerAction(payload);
+    return new BitBucketPPRPullRequestServerAction(payload, bitbucketEvent);
   }
 
   @Override
-  public void processPayload(@Nonnull BitBucketPPRPayload payload,
-      BitBucketPPRObservable observable) throws BitBucketPPRPayloadPropertyNotFoundException {
+  public void processPayload(
+      @Nonnull BitBucketPPRPayload payload, BitBucketPPRObservable observable)
+      throws BitBucketPPRPayloadPropertyNotFoundException {
 
-    jobProbe.triggerMatchingJobs(bitbucketEvent, buildActionForJobs(payload), observable);
+    jobProbe.triggerMatchingJobs(
+        bitbucketEvent, buildActionForJobs(payload, bitbucketEvent), observable);
   }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTriggerTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTriggerTest.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.bitbucketpushandpullrequest;
 
 import hudson.scm.SCM;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPullRequestServerAction;
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRServerRepositoryAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.filter.BitBucketPPRTriggerFilter;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
@@ -26,34 +25,44 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class BitBucketPPRTriggerTest {
 
-    @Test
-    public void testTriggerUrlOverridesBaseUrl() {
-        try (MockedStatic<BitBucketPPRPluginConfig> config = Mockito.mockStatic(
-                BitBucketPPRPluginConfig.class)) {
-            BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
-            config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
-            when(c.getPropagationUrl()).thenReturn("https://example.org/scm/some-namespace/some-repo.git");
+  @Test
+  public void testTriggerUrlOverridesBaseUrl() {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
+      when(c.getPropagationUrl())
+          .thenReturn("https://example.org/scm/some-namespace/some-repo.git");
 
-            BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
-            List<BitBucketPPRServerClone> clones = new ArrayList<>();
-            BitBucketPPRServerClone mockServerClone = mock(BitBucketPPRServerClone.class);
-            when(mockServerClone.getName()).thenReturn("ssh");
-            when(mockServerClone.getHref()).thenReturn("ssh://git@example.org/some-namespace/some-repo.git");
-            clones.add(mockServerClone);
-            when(payloadMock.getServerRepository().getLinks().getCloneProperty()).thenReturn(clones);
-            BitBucketPPRPullRequestServerAction bitBucketPPRServerRepositoryAction = new BitBucketPPRPullRequestServerAction(payloadMock);
-            BitBucketPPRTriggerFilter bitBucketPPRTriggerFilter = mock(BitBucketPPRTriggerFilter.class);
-            BitBucketPPRTrigger bitBucketPPRTrigger = new BitBucketPPRTrigger(List.of(bitBucketPPRTriggerFilter));
-            bitBucketPPRTrigger.setPropagationUrl("https://example2.org/scm/some-namespace/some-repo2.git");
-            BitBucketPPRHookEvent bitBucketHookEvent = mock(BitBucketPPRHookEvent.class);
+      BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
+      List<BitBucketPPRServerClone> clones = new ArrayList<>();
+      BitBucketPPRServerClone mockServerClone = mock(BitBucketPPRServerClone.class);
+      when(mockServerClone.getName()).thenReturn("ssh");
+      when(mockServerClone.getHref())
+          .thenReturn("ssh://git@example.org/some-namespace/some-repo.git");
+      clones.add(mockServerClone);
+      when(payloadMock.getServerRepository().getLinks().getCloneProperty()).thenReturn(clones);
+      BitBucketPPRHookEvent bitbucketEvent = mock(BitBucketPPRHookEvent.class);
+      BitBucketPPRPullRequestServerAction bitBucketPPRServerRepositoryAction =
+          new BitBucketPPRPullRequestServerAction(payloadMock, bitbucketEvent);
+      BitBucketPPRTriggerFilter bitBucketPPRTriggerFilter = mock(BitBucketPPRTriggerFilter.class);
+      BitBucketPPRTrigger bitBucketPPRTrigger =
+          new BitBucketPPRTrigger(List.of(bitBucketPPRTriggerFilter));
+      bitBucketPPRTrigger.setPropagationUrl(
+          "https://example2.org/scm/some-namespace/some-repo2.git");
+      BitBucketPPRHookEvent bitBucketHookEvent = mock(BitBucketPPRHookEvent.class);
 
-            SCM scmTrigger = mock(SCM.class);
-            BitBucketPPRObservable observable = mock(BitBucketPPRObservable.class);
-            bitBucketPPRTrigger.onPost(bitBucketHookEvent, bitBucketPPRServerRepositoryAction, scmTrigger, observable);
-            assertEquals("https://example2.org:-1", bitBucketPPRServerRepositoryAction.getCommitLink().split("/rest/build-status/1.0/commits/")[0]);
+      SCM scmTrigger = mock(SCM.class);
+      BitBucketPPRObservable observable = mock(BitBucketPPRObservable.class);
+      bitBucketPPRTrigger.onPost(
+          bitBucketHookEvent, bitBucketPPRServerRepositoryAction, scmTrigger, observable);
+      assertEquals(
+          "https://example2.org:-1",
+          bitBucketPPRServerRepositoryAction.getCommitLink()
+              .split("/rest/build-status/1.0/commits/")[0]);
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestActionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestActionTest.java
@@ -1,0 +1,31 @@
+package io.jenkins.plugins.bitbucketpushandpullrequest.action;
+
+import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class BitBucketPPRPullRequestActionTest {
+
+  @Test
+  public void testGetMergeCommit() {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
+      BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
+      when(payloadMock.getRepository().getLinks().getHtml().getHref())
+          .thenReturn("https://bitbucket.org/testproject/test-repo");
+      when(payloadMock.getPullRequest().getMergeCommit().getHash()).thenReturn("123456");
+      BitBucketPPRHookEvent event = mock(BitBucketPPRHookEvent.class);
+      when(event.getAction()).thenReturn("fulfilled");
+      BitBucketPPRPullRequestAction action = new BitBucketPPRPullRequestAction(payloadMock, event);
+      assertEquals("123456", action.getLatestCommit());
+    }
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
+import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.server.BitBucketPPRServerClone;
 import org.junit.Test;
@@ -11,37 +12,58 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.*;
 
 public class BitBucketPPRPullRequestServerActionTest {
-    @Test
-    public void testBaseUrlSet() {
-        try (MockedStatic<BitBucketPPRPluginConfig> config = Mockito.mockStatic(
-                BitBucketPPRPluginConfig.class)) {
-            BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
-            config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
-            when(c.isPropagationUrlSet()).thenReturn(true);
-            when(c.getPropagationUrl()).thenReturn("https://example.org/scm/some-namespace/some-repo.git");
+  @Test
+  public void testBaseUrlSet() {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
+      when(c.isPropagationUrlSet()).thenReturn(true);
+      when(c.getPropagationUrl())
+          .thenReturn("https://example.org/scm/some-namespace/some-repo.git");
 
-            BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
-            List<BitBucketPPRServerClone> clones = new ArrayList<>();
-            BitBucketPPRServerClone mockServerClone = mock(BitBucketPPRServerClone.class);
-            when(mockServerClone.getName()).thenReturn("ssh");
-            when(mockServerClone.getHref()).thenReturn("ssh://git@example.org/some-namespace/some-repo.git");
-            clones.add(mockServerClone);
-            when(payloadMock.getServerRepository().getLinks().getCloneProperty()).thenReturn(clones);
-            BitBucketPPRPullRequestServerAction bitBucketPPRPullRequestServerAction;
-            try {
-                bitBucketPPRPullRequestServerAction = new BitBucketPPRPullRequestServerAction(payloadMock);
-                assertDoesNotThrow(() -> {
-                    bitBucketPPRPullRequestServerAction.getCommitLink();
-                });
-            } catch (BitBucketPPRPayloadPropertyNotFoundException e) {
-                e.printStackTrace();
-            }
-        }
+      BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
+      List<BitBucketPPRServerClone> clones = new ArrayList<>();
+      BitBucketPPRServerClone mockServerClone = mock(BitBucketPPRServerClone.class);
+      when(mockServerClone.getName()).thenReturn("ssh");
+      when(mockServerClone.getHref())
+          .thenReturn("ssh://git@example.org/some-namespace/some-repo.git");
+      clones.add(mockServerClone);
+      when(payloadMock.getServerRepository().getLinks().getCloneProperty()).thenReturn(clones);
+      BitBucketPPRPullRequestServerAction bitBucketPPRPullRequestServerAction;
+      try {
+        BitBucketPPRHookEvent bitbucketEvent = mock(BitBucketPPRHookEvent.class);
+        when(bitbucketEvent.getAction()).thenReturn("created");
+        bitBucketPPRPullRequestServerAction =
+            new BitBucketPPRPullRequestServerAction(payloadMock, bitbucketEvent);
+        assertDoesNotThrow(
+            () -> {
+              bitBucketPPRPullRequestServerAction.getCommitLink();
+            });
+      } catch (BitBucketPPRPayloadPropertyNotFoundException e) {
+        e.printStackTrace();
+      }
     }
-    
+  }
 
+  @Test
+  public void testGetMergeCommit() throws BitBucketPPRPayloadPropertyNotFoundException {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      BitBucketPPRPluginConfig c = mock(BitBucketPPRPluginConfig.class);
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(c);
+      BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
+      when(payloadMock.getPullRequest().getMergeCommit().getHash()).thenReturn("123456");
+      BitBucketPPRHookEvent event = mock(BitBucketPPRHookEvent.class);
+      when(event.getAction()).thenReturn("fulfilled");
+      BitBucketPPRPullRequestServerAction action =
+          new BitBucketPPRPullRequestServerAction(payloadMock, event);
+      assertEquals("123456", action.getLatestCommit());
+    }
+  }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
@@ -137,7 +137,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -188,7 +188,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -239,7 +239,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -290,7 +290,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -342,7 +342,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -393,7 +393,7 @@ public class BitBucketPPREnvironmentContributorTest {
 
       BitBucketPPRPullRequestCause cause = mock(BitBucketPPRPullRequestCause.class);
       BitBucketPPRPullRequestAction bitBucketPPRPullRequestAction =
-          new BitBucketPPRPullRequestAction(payload);
+          new BitBucketPPRPullRequestAction(payload, mock(BitBucketPPRHookEvent.class));
       when(cause.getPullRequestPayLoad()).thenReturn(bitBucketPPRPullRequestAction);
       when(cause.getHookEvent()).thenReturn("X-EVENT");
 
@@ -443,7 +443,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -480,7 +481,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -517,7 +519,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -554,7 +557,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -592,7 +596,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -629,7 +634,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do
@@ -691,7 +697,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     BitBucketPPRPullRequestServerCause cause = mock(BitBucketPPRPullRequestServerCause.class);
     when(cause.getPullRequestPayLoad())
-        .thenReturn(new BitBucketPPRPullRequestServerAction(payload));
+        .thenReturn(
+            new BitBucketPPRPullRequestServerAction(payload, mock(BitBucketPPRHookEvent.class)));
     when(cause.getHookEvent()).thenReturn("X-EVENT");
 
     // do

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryPayloadProcessorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryPayloadProcessorTest.java
@@ -27,18 +27,14 @@ import org.mockito.Captor;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
-
 @RunWith(MockitoJUnitRunner.class)
 public class BitBucketPPRRepositoryPayloadProcessorTest {
 
   public BitBucketPPRPayload payload;
   public BitBucketPPRHookEvent bitbucketEvent;
-  @Captor
-  private ArgumentCaptor<BitBucketPPRHookEvent> eventCaptor;
-  @Captor
-  private ArgumentCaptor<BitBucketPPRAction> actionCaptor;
-  @Captor
-  private ArgumentCaptor<BitBucketPPRObservable> observableCaptor;
+  @Captor private ArgumentCaptor<BitBucketPPRHookEvent> eventCaptor;
+  @Captor private ArgumentCaptor<BitBucketPPRAction> actionCaptor;
+  @Captor private ArgumentCaptor<BitBucketPPRObservable> observableCaptor;
 
   @Before
   public void readPayload() {
@@ -67,8 +63,8 @@ public class BitBucketPPRRepositoryPayloadProcessorTest {
 
   @Test
   public void testRepositoryPushWebhookGit() {
-    try (MockedStatic<BitBucketPPRPluginConfig> config = mockStatic(
-        BitBucketPPRPluginConfig.class)) {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        mockStatic(BitBucketPPRPluginConfig.class)) {
       BitBucketPPRPluginConfig configInstance = mock(BitBucketPPRPluginConfig.class);
       config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(configInstance);
       BitBucketPPRJobProbe probe = mock(BitBucketPPRJobProbe.class);
@@ -85,8 +81,9 @@ public class BitBucketPPRRepositoryPayloadProcessorTest {
 
       repositoryPayloadProcessor.processPayload(payload, observable);
 
-      verify(probe).triggerMatchingJobs(eventCaptor.capture(), actionCaptor.capture(),
-          observableCaptor.capture());
+      verify(probe)
+          .triggerMatchingJobs(
+              eventCaptor.capture(), actionCaptor.capture(), observableCaptor.capture());
 
       assertEquals(bitbucketEvent, eventCaptor.getValue());
       assertEquals(payload, actionCaptor.getValue().getPayload());


### PR DESCRIPTION
Pass merge commit to the git plugin instead of the source commit when a Pull request is merged, thus correcting the behaviour of the pull request merge trigger and avoiding double builds in case of a push event and a pull request merged event at the same time fixing #201 

### Testing done
Test that the latest commit does in deed uses the merge commit from the payload in case of a pull request merge

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue