### PR TITLE
Use Server eventKey for Server Action

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
-import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_MERGED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_SERVER_MERGED;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
@@ -220,7 +220,7 @@ public class BitBucketPPRPullRequestServerAction extends BitBucketPPRActionAbstr
 
   @Override
   public String getLatestCommit() {
-    if (PULL_REQUEST_MERGED.equalsIgnoreCase(this.bitbucketEvent.getAction())) {
+    if (PULL_REQUEST_SERVER_MERGED.equalsIgnoreCase(this.bitbucketEvent.getAction())) {
       return payload.getPullRequest().getMergeCommit().getHash();
     }
     return payload.getServerPullRequest().getFromRef().getLatestCommit();

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerActionTest.java
@@ -60,7 +60,7 @@ public class BitBucketPPRPullRequestServerActionTest {
       BitBucketPPRPayload payloadMock = mock(BitBucketPPRPayload.class, RETURNS_DEEP_STUBS);
       when(payloadMock.getPullRequest().getMergeCommit().getHash()).thenReturn("123456");
       BitBucketPPRHookEvent event = mock(BitBucketPPRHookEvent.class);
-      when(event.getAction()).thenReturn("fulfilled");
+      when(event.getAction()).thenReturn("merged");
       BitBucketPPRPullRequestServerAction action =
           new BitBucketPPRPullRequestServerAction(payloadMock, event);
       assertEquals("123456", action.getLatestCommit());


### PR DESCRIPTION
Fixes #322

The if statement in `getLatestCommit` compares the eventKey to `fulfilled` instead of `merged`. This is causing merge builds to checkout the latest commit of the source branch instead of the merge commit.

Updating the constant to the BB Server constant.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->