### PR TITLE
plugin modernization to reduce hpi size

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 **Starting from version 3.2.0** the Plugin is compatible with:
 
-- Jenkins version: >= **2.452.4**
+- Jenkins version: >= **2.401.3**
 - Java version: **11**
 
 **Starting from version 3.0.0** the Plugin is compatible with:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@
 
 # Compatibility
 
-**Starting from version 3.x.x** the Plugin is compatible with:
+**Starting from version 3.2.0** the Plugin is compatible with:
+
+- Jenkins version: >= **2.452.4**
+- Java version: **11**
+
+**Starting from version 3.0.0** the Plugin is compatible with:
 
 - Jenkins version: >= **2.361.4**
 - Java version: **11**

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.401</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <powermock.version>2.0.0</powermock.version>
         <hpi.compatibleSinceVersion>2.9.0</hpi.compatibleSinceVersion>
 <!-- Readd to enable Java 17 -->
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3875.v1df09947cde6</version>
+                <version>2745.vc7b_fe4c876fa_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -93,6 +93,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
+            <version>1.87</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,18 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.53</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
 
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>bitbucket-push-and-pull-request</artifactId>
-    <version>3.1.4-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <powermock.version>2.0.0</powermock.version>
         <hpi.compatibleSinceVersion>2.9.0</hpi.compatibleSinceVersion>
 <!-- Readd to enable Java 17 -->
@@ -50,8 +51,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>1750.v0071fa_4c4a_e3</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3875.v1df09947cde6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -59,10 +60,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
@@ -78,10 +75,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci</groupId>
-            <artifactId>annotation-indexer</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -100,42 +93,37 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.81.1</version>
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>gson-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.21</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-core</artifactId>
             <version>8.3.3</version>
+            <exclusions>
+                <!-- loaded via jackson2-api plugin -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Added to avoid transitive dependency via scribejava-core-->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.14.0</version>
-        </dependency>
-
-        <!-- Added to avoid transitive dependency via scribejava-core-->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.14.0</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
         </dependency>
 
         <!-- JCasC compatibility -->

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerApprovedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerApprovedActionFilter.java
@@ -22,6 +22,7 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server;
 
 import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_REVIEWER;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
+    </Match>
+</FindBugsFilter>

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRCrumbExclusionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRCrumbExclusionTest.java
@@ -36,9 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.gargoylesoftware.htmlunit.HttpMethod;
-import com.gargoylesoftware.htmlunit.WebRequest;
-import com.gargoylesoftware.htmlunit.WebResponse;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class BitBucketPPRCrumbExclusionTest {


### PR DESCRIPTION
- use 2.401.3 as minimum Jenkins version
- replace dependencies to jackson, gson and commons-lang3 with the corresponding api plugins
- remove dependency to groovy. It is not needed and only blows up the hpi.
- remove dependencies to annotation-indexer and structs as they are not required

The size of the hpi is reduced from over 9MiB to 342KiB
<!-- Please describe your pull request here. -->

### Testing done
Don't have access to bitbucket but the tests are running fine

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
