### PR TITLE
Bitbucket Cloud - Draft Pull Request Support

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor.java
@@ -66,6 +66,7 @@ public class BitBucketPPREnvironmentContributor extends EnvironmentContributor {
       "BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_SOURCE_BRANCH";
   static final String BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_TARGET_BRANCH =
       "BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_TARGET_BRANCH";
+  static final String BITBUCKET_PULL_REQUEST_IS_DRAFT = "BITBUCKET_PULL_REQUEST_IS_DRAFT";
 
   static final Logger logger = Logger.getLogger(BitBucketPPREnvironmentContributor.class.getName());
 
@@ -192,6 +193,9 @@ public class BitBucketPPREnvironmentContributor extends EnvironmentContributor {
 
     String pullRequestId = action.getPullRequestId();
     putEnvVar(envVars, BITBUCKET_PULL_REQUEST_ID, pullRequestId);
+
+    Boolean isPullRequestDraft = action.getPayload().getPullRequest().getDraft();
+    putEnvVar(envVars, BITBUCKET_PULL_REQUEST_IS_DRAFT, isPullRequestDraft ? "true" : "false");
 
     String actor = action.getUser();
     putEnvVar(envVars, BITBUCKET_ACTOR, actor);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
@@ -32,6 +32,7 @@ public class BitBucketPPRPullRequest implements Serializable {
   private String title;
   private String description;
   private String state;
+  private Boolean draft = false;
   private BitBucketPPRActor author;
   private @SerializedName("created_on") Date createdOn;
   private @SerializedName("updated_on") Date updatedOn;
@@ -74,6 +75,9 @@ public class BitBucketPPRPullRequest implements Serializable {
   public void setState(final String state) {
     this.state = state;
   }
+
+  public Boolean getDraft() { return draft; }
+  public void setDraft(final Boolean draft) { this.draft = draft; }
 
   public BitBucketPPRCommit getMergeCommit() {
     return mergeCommit;
@@ -165,6 +169,8 @@ public class BitBucketPPRPullRequest implements Serializable {
         + description
         + ", state="
         + state
+        + ", draft="
+        + draft
         + ", author="
         + author
         + ", createdOn="

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor/buildEnv.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor/buildEnv.jelly
@@ -92,5 +92,9 @@ THE SOFTWARE.
   <t:buildEnvVar name="BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_TARGET_BRANCH">
     <j:out value="${%blurb.BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_TARGET_BRANCH}"/>
   </t:buildEnvVar>
+
+  <t:buildEnvVar name="BITBUCKET_PULL_REQUEST_IS_DRAFT">
+    <j:out value="${%blurb.BITBUCKET_PULL_REQUEST_IS_DRAFT}"/>
+  </t:buildEnvVar>
   
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor/buildEnv.properties
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor/buildEnv.properties
@@ -37,3 +37,4 @@ blurb.REPOSITORY_LINK= Repository link - only for BB Cloud pushs (Deprecated. It
 blurb.REPOSITORY_NAME=Repository name - only for BB Server pushs (Deprecated. to be removed in v2.6) (BB Server)
 blurb.BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_SOURCE_BRANCH=Latest commit hash on the source branch
 blurb.BITBUCKET_PULL_REQUEST_LATEST_COMMIT_FROM_TARGET_BRANCH=Latest commit hash on the target branch
+blurb.BITBUCKET_PULL_REQUEST_IS_DRAFT=Pull Request Is Draft - only for BB Cloud pull request.


### PR DESCRIPTION
Bitbucket Cloud Pull Request - add the ability to be able to detect if a Pull Request is a Draft - assume false for when Payload doesn't provide draft key.

### Testing done
Ran the included maven tests and within `testProcessPullRequestApprovalWebhookGit` - I outputted `actionCaptor.getValue().getPayload().getPullRequest()` to ensure that `draft=false` - as `draft` isn't included in the existing dataset.
Bitbucket Cloud Event Payloads (https://support.atlassian.com/bitbucket-cloud/docs/event-payloads/#Pull-request) specify that the Pull Request object should return `draft`. This may not be happening in practice as it appears to have only been incorporated into Bitbucket Cloud in the last 6 months.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
