### PR TITLE
Fix/maven build plugin repo update

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,17 +36,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v2.3.1
+      uses: actions/setup-java@v4
       with:
         java-version: 17
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     # - name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,4 +70,4 @@ jobs:
       run: mvn -DskipTests=true -V -ntp install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,13 +37,13 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    
+
     - name: Setup Java JDK
       uses: actions/setup-java@v2.3.1
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'adopt'
-    
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -65,7 +65,7 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-    
+
     - name: Build with Maven
       run: mvn -DskipTests=true -V -ntp install
 

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v3
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
-      # java-version: 21 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.
+      java-version: 17 # Specify Java 17 to match the project requirements

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v3
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2.2.1
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 17 # Specify Java 17 to match the project requirements

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,11 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],
 ])
-

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.17</version>
         <relativePath />
     </parent>
 
@@ -16,15 +16,14 @@
 
     <properties>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.440</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-        <powermock.version>2.0.0</powermock.version>
         <hpi.compatibleSinceVersion>2.9.0</hpi.compatibleSinceVersion>
         <jenkins.java.level>17</jenkins.java.level>
     </properties>
 
     <name>Bitbucket Push and Pull Request Plugin</name>
-    <description>Bitbucket plugin for Jenkins v2.138.2 or later, allowing push and pull requests</description>
+    <description>Bitbucket plugin for Jenkins allowing push and pull requests</description>
 
     <licenses>
         <license>
@@ -49,7 +48,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3435.v238d66a_043fb_</version>
+                <version>4770.v9a_2b_7a_9d8b_7f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -198,7 +197,6 @@
             <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <url>https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin</url>
@@ -243,5 +241,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -212,13 +212,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins.io/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>https://repo.jenkins.io/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.17</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
 
@@ -16,8 +16,9 @@
 
     <properties>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.baseline>2.440</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <powermock.version>2.0.0</powermock.version>
         <hpi.compatibleSinceVersion>2.9.0</hpi.compatibleSinceVersion>
         <jenkins.java.level>17</jenkins.java.level>
     </properties>
@@ -48,7 +49,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>4770.v9a_2b_7a_9d8b_7f</version>
+                <version>3435.v238d66a_043fb_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
@@ -55,7 +55,7 @@ import jenkins.triggers.SCMTriggerItem;
 import org.eclipse.jgit.transport.URIish;
 
 /**
- * 
+ *
  * @author cdelmonte
  *
  */
@@ -92,7 +92,7 @@ public class BitBucketPPRJobProbe {
     List<URIish> remoteScmUrls = bitbucketAction.getScmUrls().stream().map(makeUrl)
         .filter(Objects::nonNull).collect(Collectors.toList());
 
-    try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+    try (ACLContext ctx = ACL.as2(ACL.SYSTEM2)) {
       if (globalConfig.isSingleJobSet()) {
         try {
           Job job = (Job) Jenkins.get().getItemByFullName(globalConfig.getSingleJob());
@@ -159,7 +159,7 @@ public class BitBucketPPRJobProbe {
         return;
       }
 
-      Predicate<URIish> checkSCM = (url) -> scm instanceof GitSCM && matchGitScm(scm, url);
+      Predicate<URIish> checkSCM = url -> scm instanceof GitSCM && matchGitScm(scm, url);
 
       if (remotes.stream().anyMatch(checkSCM) && !scmTriggered.contains(scm)) {
         scmTriggered.add(scm);
@@ -230,11 +230,9 @@ public class BitBucketPPRJobProbe {
   }
 
   private Optional<BitBucketPPRTrigger> getBitBucketTrigger(Job<?, ?> job) {
-    if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
-      ParameterizedJobMixIn.ParameterizedJob<?, ?> pJob =
-          (ParameterizedJobMixIn.ParameterizedJob<?, ?>) job;
+    if (job instanceof ParameterizedJobMixIn.ParameterizedJob<?, ?> pJob) {
 
-      return pJob.getTriggers().values().stream().filter(BitBucketPPRTrigger.class::isInstance)
+        return pJob.getTriggers().values().stream().filter(BitBucketPPRTrigger.class::isInstance)
           .findFirst().map(BitBucketPPRTrigger.class::cast);
     }
     return Optional.empty();

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRPollResultListener.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRPollResultListener.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -26,7 +26,7 @@ import hudson.scm.PollingResult;
 
 
 public interface BitBucketPPRPollResultListener {
-  public void onPollSuccess(PollingResult pollingResult);
+  void onPollSuccess(PollingResult pollingResult);
 
-  public void onPollError(Throwable throwable);
+  void onPollError(Throwable throwable);
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTrigger.java
@@ -27,17 +27,16 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.*;
 import org.apache.commons.jelly.XMLOutput;
 import org.eclipse.jgit.transport.URIish;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -45,7 +44,6 @@ import org.kohsuke.stapler.QueryParameter;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.Extension;
 import hudson.Util;
 import hudson.console.AnnotatedLargeText;
@@ -54,7 +52,6 @@ import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
-import hudson.model.Build;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.scm.PollingResult;
@@ -65,7 +62,6 @@ import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import hudson.util.SequentialExecutionQueue;
 import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
-import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventContext;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventFactory;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventType;
@@ -152,7 +148,7 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
 
                 @Override
                 public void onPollSuccess(PollingResult pollingResult) {
-                  matchingFilters.stream()
+                  matchingFilters
                       .forEach(
                           filter -> {
                             try {
@@ -254,7 +250,7 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
     if (f == null) return;
 
     try {
-      Run<?, ?> startedBuild = (Run<?, ?>) f.waitForStart();
+      Run<?, ?> startedBuild = f.waitForStart();
 
       logger.info(String.format("Triggering %s # %d", job.getName(), startedBuild.getNumber()));
 
@@ -264,7 +260,7 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
               new BitBucketPPREventContext(
                   this, bitbucketAction, scmTrigger, startedBuild, filter)));
 
-      Run<?, ?> run = (Run<?, ?>) f.get();
+      Run<?, ?> run = f.get();
 
       if (f.isDone()) {
         observable.notifyObservers(
@@ -330,8 +326,8 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
         value = "RV_RETURN_VALUE_IGNORED",
         justification = "I know what I'm doing")
     public void writeLogTo(XMLOutput out) throws Exception {
-      new AnnotatedLargeText<BitBucketPPRWebHookPollingAction>(
-              getLogFile(), Charset.defaultCharset(), true, this)
+        new AnnotatedLargeText<>(
+                getLogFile(), Charset.defaultCharset(), true, this)
           .writeHtmlTo(0, out.asWriter());
     }
   }
@@ -355,10 +351,10 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
       return new StandardListBoxModel()
           .includeEmptyValue()
           .includeMatchingAs(
-              ACL.SYSTEM,
+              ACL.SYSTEM2,
               context,
               StandardCredentials.class,
-              Collections.<DomainRequirement>emptyList(),
+              Collections.emptyList(),
               CredentialsMatchers.always())
           .includeCurrentValue(credentialsId);
     }
@@ -370,6 +366,7 @@ public class BitBucketPPRTrigger extends Trigger<Job<?, ?>> {
           && item instanceof ParameterizedJobMixIn.ParameterizedJob;
     }
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Build with BitBucket Push and Pull Request Plugin";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRAction.java
@@ -29,116 +29,116 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 
 public interface BitBucketPPRAction extends Action {
 
-  public BitBucketPPRPayload getPayload();
+  BitBucketPPRPayload getPayload();
 
-  public String getScm();
+  String getScm();
 
-  public default String getLinkHtml() {
+  default String getLinkHtml() {
     return null;
   }
 
-  public default String getLinkSelf() {
+  default String getLinkSelf() {
     return null;
   }
 
-  public default String getLinkApprove() throws MalformedURLException {
+  default String getLinkApprove() throws MalformedURLException {
     return null;
   }
 
-  public default String getLinkDecline() throws MalformedURLException {
+  default String getLinkDecline() throws MalformedURLException {
     return null;
   }
 
-  public default String getLinkStatuses() {
+  default String getLinkStatuses() {
     return null;
   }
 
-  public default String getUser() {
+  default String getUser() {
     return null;
   }
 
-  public default String getSourceBranch() {
+  default String getSourceBranch() {
     return null;
   }
 
-  public default String getTargetBranch() {
+  default String getTargetBranch() {
     return null;
   }
 
-  public default String getTargetBranchRefId() {
+  default String getTargetBranchRefId() {
     return null;
   }
 
-  public default String getType() {
+  default String getType() {
     return null;
   }
 
-  public default String getRepositoryName() {
+  default String getRepositoryName() {
     return null;
   }
 
   // TODO: do we really neeed it?
-  public default List<String> getScmUrls() {
+  default List<String> getScmUrls() {
     return null;
   }
 
-  public default String getPullRequestId() {
+  default String getPullRequestId() {
     return null;
   }
 
-  public default String getRepositoryId() {
+  default String getRepositoryId() {
     return null;
   }
 
-  public default String getRepositoryUrl() {
+  default String getRepositoryUrl() {
     return null;
   }
 
-  public default String getProjectUrl() {
+  default String getProjectUrl() {
     return null;
   }
 
-  public default String getPullRequestApiUrl() {
+  default String getPullRequestApiUrl() {
     return null;
   }
 
-  public default String getPullRequestUrl() {
+  default String getPullRequestUrl() {
     return null;
   }
 
-  public default String getTitle() {
+  default String getTitle() {
     return null;
   }
 
-  public default String getDescription() {
+  default String getDescription() {
     return null;
   }
 
-  public default String getComment() {
+  default String getComment() {
     return null;
   }
 
-  public default String getServerComment() {
+  default String getServerComment() {
     return null;
   }
 
-  public default String getLatestCommit() {
+  default String getLatestCommit() {
     return null;
   }
 
-  public default String getCommitLink() throws MalformedURLException {
+  default String getCommitLink() throws MalformedURLException {
     return null;
   }
 
-  public default List<String> getCommitLinks() throws MalformedURLException {
+  default List<String> getCommitLinks() throws MalformedURLException {
     return null;
   }
 
-  public default String getLatestCommitFromRef() {
+  default String getLatestCommitFromRef() {
     return null;
   }
 
-  public default String getLatestCommitToRef() {
+  default String getLatestCommitToRef() {
     return null;
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestAction.java
@@ -21,6 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRRepositoryNotParsedException;
 
@@ -127,6 +128,7 @@ public class BitBucketPPRPullRequestAction extends BitBucketPPRActionAbstract
     return payload.getPullRequest().getDescription();
   }
 
+  @NonNull
   @Override
   public BitBucketPPRPayload getPayload() {
     return payload;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPullRequestServerAction.java
@@ -21,6 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
@@ -148,6 +149,7 @@ public class BitBucketPPRPullRequestServerAction extends BitBucketPPRActionAbstr
     return payload.getServerPullRequest().getTitle();
   }
 
+  @NonNull
   @Override
   public BitBucketPPRPayload getPayload() {
     return payload;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRRepositoryAction.java
@@ -21,6 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRRepositoryNotParsedException;
 
@@ -92,6 +93,7 @@ public class BitBucketPPRRepositoryAction extends BitBucketPPRActionAbstract
     return payload.getRepository().getLinks().getHtml().getHref();
   }
 
+  @NonNull
   @Override
   public BitBucketPPRPayload getPayload() {
     return payload;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRServerRepositoryAction.java
@@ -21,7 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.action;
 
-import hudson.model.InvisibleAction;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.server.BitBucketPPRServerChange;
@@ -50,7 +50,7 @@ public class BitBucketPPRServerRepositoryAction extends BitBucketPPRActionAbstra
   private String targetBranchRefId = null;
   private String type;
 
-  public BitBucketPPRServerRepositoryAction(BitBucketPPRPayload payload) {
+  public BitBucketPPRServerRepositoryAction(@NonNull BitBucketPPRPayload payload) {
     this.payload = payload;
 
     // TODO: do we need link clones or link self is enough??
@@ -97,6 +97,7 @@ public class BitBucketPPRServerRepositoryAction extends BitBucketPPRActionAbstra
     return targetBranchRefId;
   }
 
+  @NonNull
   @Override
   public BitBucketPPRPayload getPayload() {
     return payload;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/BitBucketPPRTriggerCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/BitBucketPPRTriggerCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -34,7 +34,7 @@ public class BitBucketPPRTriggerCause extends SCMTrigger.SCMTriggerCause {
   protected BitBucketPPRAction bitbucketAction;
   protected BitBucketPPRHookEvent bitBucketHookEvent;
 
-  public BitBucketPPRTriggerCause(File pollingLog, BitBucketPPRAction bitbucketAction, 
+  public BitBucketPPRTriggerCause(File pollingLog, BitBucketPPRAction bitbucketAction,
       BitBucketPPRHookEvent bitBucketHookEvent)
       throws IOException {
     super(pollingLog);
@@ -68,11 +68,8 @@ public class BitBucketPPRTriggerCause extends SCMTrigger.SCMTriggerCause {
       return false;
     BitBucketPPRTriggerCause other = (BitBucketPPRTriggerCause) obj;
     if (bitbucketAction == null) {
-      if (other.bitbucketAction != null)
-        return false;
-    } else if (!bitbucketAction.equals(other.bitbucketAction))
-      return false;
-    return true;
+        return other.bitbucketAction == null;
+    } else return bitbucketAction.equals(other.bitbucketAction);
   }
 
   @Override

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestApprovedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestApprovedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -41,7 +41,7 @@ public class BitBucketPPRPullRequestCause extends BitBucketPPRTriggerCause {
   public BitBucketPPRPullRequestAction getPullRequestPayLoad() {
     return (BitBucketPPRPullRequestAction) super.getAction();
   }
-  
+
   @Override
   public String getShortDescription() {
     String pusher = bitbucketAction.getUser() != null ? bitbucketAction.getUser() : "";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentCreatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentCreatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentDeletedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentDeletedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentUpdatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCommentUpdatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCreatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestCreatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestDeclinedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestDeclinedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestMergedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestMergedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestUpdatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/cloud/BitBucketPPRPullRequestUpdatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerApprovedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerApprovedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -33,7 +33,7 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEven
 
 public class BitBucketPPRPullRequestServerCause extends BitBucketPPRTriggerCause {
 
-  public BitBucketPPRPullRequestServerCause(File pollingLog, BitBucketPPRAction bitbucketAction, 
+  public BitBucketPPRPullRequestServerCause(File pollingLog, BitBucketPPRAction bitbucketAction,
       BitBucketPPRHookEvent bitBucketHookEvent)
       throws IOException {
     super(pollingLog, bitbucketAction, bitBucketHookEvent);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCommentCreatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCommentCreatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCreatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerCreatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerUpdatedCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/pullrequest/server/BitBucketPPRPullRequestServerUpdatedCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/repository/BitBucketPPRRepositoryCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/repository/BitBucketPPRRepositoryCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/repository/BitBucketPPRServerRepositoryCause.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/cause/repository/BitBucketPPRServerRepositoryCause.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -31,7 +31,7 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEven
 
 public class BitBucketPPRServerRepositoryCause extends BitBucketPPRTriggerCause {
 
-  public BitBucketPPRServerRepositoryCause(File pollingLog, BitBucketPPRAction bitbucketAction, 
+  public BitBucketPPRServerRepositoryCause(File pollingLog, BitBucketPPRAction bitbucketAction,
       BitBucketPPRHookEvent bitBucketHookEvent)
       throws IOException {
     super(pollingLog, bitbucketAction, bitBucketHookEvent);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClient.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClient.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -23,7 +23,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.client;
 import com.github.scribejava.core.model.Verb;
 
 public interface BitBucketPPRClient {
-  public void send(String url, String payload) throws Exception;
-  public void send(Verb verb, String url, String payload) throws Exception;
-  public void accept(BitBucketPPRClientVisitor visitor);
+  void send(String url, String payload) throws Exception;
+  void send(Verb verb, String url, String payload) throws Exception;
+  void accept(BitBucketPPRClientVisitor visitor);
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientCloudVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientCloudVisitor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2021, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -49,10 +49,10 @@ public class BitBucketPPRClientCloudVisitor implements BitBucketPPRClientVisitor
   @Override
   public void send(StandardCredentials credentials, Verb verb, String url, String payload)
       throws InterruptedException, NoSuchMethodException {
-    if (credentials instanceof StandardUsernamePasswordCredentials)
+    if (credentials instanceof StandardUsernamePasswordCredentials usernamePasswordCredentials)
       try {
         final HttpResponse response =
-            this.send((StandardUsernamePasswordCredentials) credentials, verb, url, payload);
+            this.send(usernamePasswordCredentials, verb, url, payload);
         HttpEntity responseEntity = response.getEntity();
         final String responseBody =
             responseEntity == null ? "empty" : EntityUtils.toString(responseEntity);
@@ -62,16 +62,14 @@ public class BitBucketPPRClientCloudVisitor implements BitBucketPPRClientVisitor
       } catch (IOException e) {
         logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
       }
-    else if (credentials instanceof StringCredentials) {
+    else if (credentials instanceof StringCredentials stringCredentials) {
       try {
-        Response response = this.send((StringCredentials) credentials, verb, url, payload);
+        Response response = this.send(stringCredentials, verb, url, payload);
 
         logger.log(Level.FINEST, "Result of the state notification is: {0}, with status code: {1}",
             new Object[] {response.getBody(), response.getCode()});
       } catch (ExecutionException | IOException e) {
         logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
-      } catch (InterruptedException e) {
-        throw e;
       }
     } else
       throw new NotImplementedException("Credentials provider for state notification not found");

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientFactory.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientServerVisitor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.lang.NotImplementedException;
@@ -44,18 +43,18 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
 
   @Override
   public void send(StandardCredentials credentials, String url, String payload)
-      throws InterruptedException, NoSuchMethodException {
+      throws NoSuchMethodException {
     send(credentials, Verb.POST, url, payload);
   }
 
   @Override
   public void send(StandardCredentials credentials, Verb verb, String url, String payload)
-      throws InterruptedException, NoSuchMethodException {
+      throws NoSuchMethodException {
 
-    if (credentials instanceof StandardUsernamePasswordCredentials)
+    if (credentials instanceof StandardUsernamePasswordCredentials usernamePasswordCredentials)
       try {
         final HttpResponse response =
-            this.send((StandardUsernamePasswordCredentials) credentials, verb, url, payload);
+            this.send(usernamePasswordCredentials, verb, url, payload);
         HttpEntity responseEntity = response.getEntity();
         final String responseBody =
             responseEntity == null ? "empty" : EntityUtils.toString(responseEntity);
@@ -65,17 +64,14 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
       } catch (IOException e) {
         logger.log(Level.WARNING, "Error during state notification: {0} ", e.getMessage());
       }
-    else if (credentials instanceof StringCredentials)
+    else if (credentials instanceof StringCredentials stringCredentials)
       try {
-        HttpResponse response = this.send((StringCredentials) credentials, verb, url, payload);
+        HttpResponse response = this.send(stringCredentials, verb, url, payload);
         logger.log(Level.FINEST, "Result of the state notification is: {0}, with status code: {1}",
             new Object[] {response.getEntity().getContent(),
                 response.getStatusLine().getStatusCode()});
-      } catch (ExecutionException | IOException | KeyManagementException | NoSuchAlgorithmException
-          | KeyStoreException e) {
+      } catch (IOException | KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
         logger.log(Level.WARNING, "Error du" + "ring state notification: {0} ", e.getMessage());
-      } catch (InterruptedException e) {
-        throw e;
       }
     else
       throw new NotImplementedException("Credentials provider for state notification not found");
@@ -88,7 +84,7 @@ public class BitBucketPPRClientServerVisitor implements BitBucketPPRClientVisito
   }
 
   private HttpResponse send(StringCredentials credentials, Verb verb, String url, String payload)
-      throws InterruptedException, ExecutionException, IOException, KeyManagementException,
+      throws IOException, KeyManagementException,
       NoSuchAlgorithmException, KeyStoreException, NoSuchMethodException {
     logger.finest("Set BB StringCredentials for BB Server state notification");
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientType.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientType.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,5 +21,5 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.client;
 
 public enum BitBucketPPRClientType {
-  CLOUD, SERVER;
+  CLOUD, SERVER
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientVisitor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRClientVisitor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -25,10 +25,10 @@ import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.github.scribejava.core.model.Verb;
 
 public interface BitBucketPPRClientVisitor {
-  public void send(StandardCredentials credentials, String url, String payload)
+  void send(StandardCredentials credentials, String url, String payload)
       throws InterruptedException, IOException, NoSuchMethodException;
 
-  public void send(StandardCredentials credentials, Verb verb, String url, String payload)
+  void send(StandardCredentials credentials, Verb verb, String url, String payload)
       throws InterruptedException, NoSuchMethodException;
 
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRCloudClient.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRCloudClient.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,7 +21,6 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.client;
 
 import com.github.scribejava.core.model.Verb;
-import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventContext;
 
 
@@ -45,7 +44,7 @@ public class BitBucketPPRCloudClient implements BitBucketPPRClient {
 
   @Override
   public void send(Verb verb, String url, String payload) throws Exception {
-    visitor.send(context.getStandardCredentials(), verb, url, payload);    
+    visitor.send(context.getStandardCredentials(), verb, url, payload);
   }
 
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRServerClient.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/BitBucketPPRServerClient.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,7 +21,6 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.client;
 
 import com.github.scribejava.core.model.Verb;
-import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRUtils;
 import io.jenkins.plugins.bitbucketpushandpullrequest.event.BitBucketPPREventContext;
 
 public class BitBucketPPRServerClient implements BitBucketPPRClient {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
@@ -3,7 +3,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.config;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Item;
@@ -16,7 +16,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import javax.annotation.CheckForNull;
 import java.net.MalformedURLException;
@@ -106,7 +106,7 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   }
 
   @DataBoundSetter
-  public void setNotifyBitBucket(@CheckForNull boolean notifyBitBucket) {
+  public void setNotifyBitBucket(boolean notifyBitBucket) {
     this.notifyBitBucket = notifyBitBucket;
   }
 
@@ -115,7 +115,7 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   }
 
   @DataBoundSetter
-  public void setUseJobNameAsBuildKey(@CheckForNull boolean useJobNameAsBuildKey) {
+  public void setUseJobNameAsBuildKey(boolean useJobNameAsBuildKey) {
     this.useJobNameAsBuildKey = useJobNameAsBuildKey;
     save();
   }
@@ -147,13 +147,14 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
     return singleJob;
   }
 
+  @NonNull
   @Override
   public String getDisplayName() {
     return "Bitbucket Push and Pull Request";
   }
 
   @Override
-  public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+  public boolean configure(StaplerRequest2 req, JSONObject formData) {
     req.bindJSON(this, formData);
     save();
     return true;
@@ -172,10 +173,10 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
     return new StandardListBoxModel()
         .includeEmptyValue()
         .includeMatchingAs(
-            ACL.SYSTEM,
-            Jenkins.getInstance(),
+            ACL.SYSTEM2,
+            Jenkins.get(),
             StandardCredentials.class,
-            Collections.<DomainRequirement>emptyList(),
+            Collections.emptyList(),
             CredentialsMatchers.always())
         .includeCurrentValue(credentialsId);
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
@@ -1,8 +1,22 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.config;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
@@ -13,18 +27,6 @@ import hudson.util.ListBoxModel;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest2;
-
-import javax.annotation.CheckForNull;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.logging.Logger;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Extension
 public class BitBucketPPRPluginConfig extends GlobalConfiguration {
@@ -154,7 +156,7 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   }
 
   @Override
-  public boolean configure(StaplerRequest2 req, JSONObject formData) {
+  public boolean configure(StaplerRequest req, JSONObject formData) {
     req.bindJSON(this, formData);
     save();
     return true;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributor.java
@@ -21,10 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.environment;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixBuild;
@@ -70,19 +71,17 @@ public class BitBucketPPREnvironmentContributor extends EnvironmentContributor {
   static final Logger logger = Logger.getLogger(BitBucketPPREnvironmentContributor.class.getName());
 
   @Override
-  public void buildEnvironmentFor(Job job, EnvVars envVars, TaskListener taskListener)
-      throws IOException, InterruptedException {
+  public void buildEnvironmentFor(@NonNull Job job, @NonNull EnvVars envVars, @NonNull TaskListener taskListener) {
     // NOTHING TO DO HERE
   }
 
   @Override
-  public void buildEnvironmentFor(@Nonnull Run run, EnvVars envVars, TaskListener taskListener)
-      throws IOException, InterruptedException {
+  public void buildEnvironmentFor(@Nonnull Run run, @NonNull EnvVars envVars, @NonNull TaskListener taskListener) {
 
     List<Cause> causes = null;
 
-    if (run instanceof MatrixRun) {
-      MatrixBuild parent = ((MatrixRun) run).getParentBuild();
+    if (run instanceof MatrixRun matrixRun) {
+      MatrixBuild parent = matrixRun.getParentBuild();
       if (parent != null) {
         causes = parent.getCauses();
       }
@@ -94,30 +93,25 @@ public class BitBucketPPREnvironmentContributor extends EnvironmentContributor {
       return;
     }
 
-    causes.stream().forEach((Cause cause) -> {
+    causes.forEach((Cause cause) -> {
       try {
-        if (cause instanceof BitBucketPPRPullRequestCause) {
-          BitBucketPPRPullRequestCause castedCause = (BitBucketPPRPullRequestCause) cause;
-          setEnvVarsForCloudPullRequest(envVars, castedCause.getPullRequestPayLoad(),
+        if (cause instanceof BitBucketPPRPullRequestCause castedCause) {
+            setEnvVarsForCloudPullRequest(envVars, castedCause.getPullRequestPayLoad(),
               castedCause.getHookEvent());
-        } else if (cause instanceof BitBucketPPRPullRequestServerCause) {
-          BitBucketPPRPullRequestServerCause castedCause =
-              (BitBucketPPRPullRequestServerCause) cause;
-          setEnvVarsForServerPullRequest(envVars, castedCause.getPullRequestPayLoad(),
+        } else if (cause instanceof BitBucketPPRPullRequestServerCause castedCause) {
+            setEnvVarsForServerPullRequest(envVars, castedCause.getPullRequestPayLoad(),
               castedCause.getHookEvent());
-        } else if (cause instanceof BitBucketPPRRepositoryCause) {
-          BitBucketPPRRepositoryCause castedCause = (BitBucketPPRRepositoryCause) cause;
-          setEnvVarsForCloudRepository(envVars, castedCause.getRepositoryPayLoad(),
+        } else if (cause instanceof BitBucketPPRRepositoryCause castedCause) {
+            setEnvVarsForCloudRepository(envVars, castedCause.getRepositoryPayLoad(),
               castedCause.getHookEvent());
-        } else if (cause instanceof BitBucketPPRServerRepositoryCause) {
-          BitBucketPPRServerRepositoryCause castedCause = (BitBucketPPRServerRepositoryCause) cause;
-          setEnvVarsForServerRepository(envVars, castedCause.getServerRepositoryPayLoad(),
+        } else if (cause instanceof BitBucketPPRServerRepositoryCause castedCause) {
+            setEnvVarsForServerRepository(envVars, castedCause.getServerRepositoryPayLoad(),
               castedCause.getHookEvent());
         }
       } catch (Exception e) {
         e.printStackTrace();
         logger.warning(String.format("Cannot build environment variables for cause %s %s.",
-            cause.getShortDescription(), e.toString()));
+            cause.getShortDescription(), e));
       }
     });
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPRBuildFinished.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPRBuildFinished.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPRBuildStarted.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPRBuildStarted.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREvent.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREvent.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -23,8 +23,8 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.event;
 import io.jenkins.plugins.bitbucketpushandpullrequest.observer.BitBucketPPRHandlerTemplate;
 
 public interface BitBucketPPREvent {
-  public void setContext(BitBucketPPREventContext context);
-  public BitBucketPPREventContext getContext();
-  public void setEventHandler(BitBucketPPRHandlerTemplate handler);
-  public void runHandler();
+  void setContext(BitBucketPPREventContext context);
+  BitBucketPPREventContext getContext();
+  void setEventHandler(BitBucketPPRHandlerTemplate handler);
+  void runHandler();
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventContext.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventContext.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -44,7 +44,7 @@ public class BitBucketPPREventContext {
   private BitBucketPPRTrigger trigger;
 
   public BitBucketPPREventContext(BitBucketPPRTrigger trigger, BitBucketPPRAction action,
-      SCM scmTrigger, Run<?, ?> run, BitBucketPPRTriggerFilter filter) throws Exception {
+      SCM scmTrigger, Run<?, ?> run, BitBucketPPRTriggerFilter filter) {
     this.action = action;
     this.scmTrigger = scmTrigger;
     this.run = run;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventFactory.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -23,21 +23,14 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.event;
 public class BitBucketPPREventFactory {
   public static BitBucketPPREvent createEvent(BitBucketPPREventType eventType, BitBucketPPREventContext context)
       throws Exception {
-    BitBucketPPREvent event = null;
+    BitBucketPPREvent event = switch (eventType) {
+        case BUILD_STARTED -> new BitBucketPPRBuildStarted();
+        case BUILD_FINISHED -> new BitBucketPPRBuildFinished();
+        default -> throw new Exception();
+    };
 
-    switch (eventType) {
-      case BUILD_STARTED:
-        event = new BitBucketPPRBuildStarted();
-        break;
-      case BUILD_FINISHED:
-        event = new BitBucketPPRBuildFinished();
-        break;
-      default:
-        throw new Exception();
-    }
+      event.setContext(context);
 
-    event.setContext(context);
-    
     return event;
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventType.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/event/BitBucketPPREventType.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,7 +21,7 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.event;
 
 public enum BitBucketPPREventType {
-  BUILD_STARTED, BUILD_FINISHED;
+  BUILD_STARTED, BUILD_FINISHED
 
 
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/exception/BitBucketPPRObserverNotFoundException.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/exception/BitBucketPPRObserverNotFoundException.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,7 +20,10 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.exception;
 
+import java.io.Serial;
+
 public class BitBucketPPRObserverNotFoundException extends Exception {
+  @Serial
   private static final long serialVersionUID = 1L;
 
   public BitBucketPPRObserverNotFoundException(String msg) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/exception/JobNotStartedException.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/exception/JobNotStartedException.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.exception;
 
+import java.io.Serial;
+
 public class JobNotStartedException extends Exception {
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public JobNotStartedException(String msg) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslContext.java
@@ -356,8 +356,8 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerApprovedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
-  
-  
+
+
   @Deprecated
   public void pullRequestServerApprovedAction(boolean onlyIfReviewersApproved,
       String allowedBranches, boolean isToApprove) {
@@ -395,7 +395,7 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerCreatedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
-  
+
   public void pullRequestServerCreatedAction(String allowedBranches, boolean isToApprove, boolean isToDecline) {
     BitBucketPPRPullRequestServerCreatedActionFilter pullRequestServerCreatedActionFilter =
         new BitBucketPPRPullRequestServerCreatedActionFilter();
@@ -433,7 +433,7 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRPullRequestServerTriggerFilter(pullRequestUpdatedServerActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
-  
+
   public void pullRequestServerUpdatedAction(String allowedBranches, boolean isToApprove, boolean isToDecline) {
     BitBucketPPRPullRequestServerUpdatedActionFilter pullRequestUpdatedServerActionFilter =
         new BitBucketPPRPullRequestServerUpdatedActionFilter();
@@ -471,7 +471,7 @@ public class BitBucketPPRHookJobDslContext implements Context {
         new BitBucketPPRPullRequestServerTriggerFilter(pullRequestServerSourceUpdatedActionFilter);
     triggers.add(pullRequestServerTriggerFilter);
   }
-  
+
   public void pullRequestServerSourceUpdatedAction(String allowedBranches, boolean isToApprove, boolean isToDecline) {
     BitBucketPPRPullRequestServerSourceUpdatedActionFilter pullRequestServerSourceUpdatedActionFilter =
         new BitBucketPPRPullRequestServerSourceUpdatedActionFilter();

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/extensions/dsl/BitBucketPPRHookJobDslExtension.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPREventTriggerMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPREventTriggerMatcher.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRFilterMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRFilterMatcher.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRTriggerFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRTriggerFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -40,6 +40,6 @@ public abstract class BitBucketPPRTriggerFilter extends AbstractDescribableImpl<
   public abstract boolean shouldTriggerAlsoIfNothingChanged();
 
   public abstract boolean shouldSendApprove();
-  
+
   public abstract boolean shouldSendDecline();
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRTriggerFilterDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/BitBucketPPRTriggerFilterDescriptor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestActionDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestActionDescriptor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestActionFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestApprovedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestApprovedActionFilter.java
@@ -24,8 +24,10 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_REVIEWER;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -52,11 +54,7 @@ public class BitBucketPPRPullRequestApprovedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @Override
@@ -90,6 +88,7 @@ public class BitBucketPPRPullRequestApprovedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Approved";
@@ -101,10 +100,7 @@ public class BitBucketPPRPullRequestApprovedActionFilter
   }
 
   private boolean allReviewersHaveApproved(BitBucketPPRAction pullRequestAction) {
-    return pullRequestAction.getPayload().getPullRequest().getParticipants().stream()
-            .filter(p -> isReviewer(p) && !p.getApproved())
-            .count()
-        == 0;
+    return pullRequestAction.getPayload().getPullRequest().getParticipants().stream().noneMatch(p -> isReviewer(p) && !p.getApproved());
   }
 
   private boolean isReviewer(BitBucketPPRParticipant pullRequestParticipant) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentCreatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentCreatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -47,20 +49,12 @@ public class BitBucketPPRPullRequestCommentCreatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
   public void setCommentFilter(String commentFilter) {
-    if (commentFilter == null) {
-      this.commentFilter = "";
-    } else {
-      this.commentFilter = commentFilter;
-    }
+      this.commentFilter = Objects.requireNonNullElse(commentFilter, "");
   }
 
   @Override
@@ -95,6 +89,7 @@ public class BitBucketPPRPullRequestCommentCreatedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Comment Created";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentDeletedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentDeletedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -44,11 +46,7 @@ public class BitBucketPPRPullRequestCommentDeletedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @Override
@@ -78,6 +76,7 @@ public class BitBucketPPRPullRequestCommentDeletedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Comment Deleted";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentUpdatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCommentUpdatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -47,20 +49,12 @@ public class BitBucketPPRPullRequestCommentUpdatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
   public void setCommentFilter(String commentFilter) {
-    if (commentFilter == null) {
-      this.commentFilter = "";
-    } else {
-      this.commentFilter = commentFilter;
-    }
+      this.commentFilter = Objects.requireNonNullElse(commentFilter, "");
   }
 
   @Override
@@ -95,6 +89,7 @@ public class BitBucketPPRPullRequestCommentUpdatedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Comment Updated";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCreatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestCreatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -46,11 +48,7 @@ public class BitBucketPPRPullRequestCreatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -89,6 +87,7 @@ public class BitBucketPPRPullRequestCreatedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Created";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestDeclinedActionFilter.java
@@ -21,6 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
@@ -32,6 +33,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 public class BitBucketPPRPullRequestDeclinedActionFilter
     extends BitBucketPPRPullRequestActionFilter {
@@ -42,11 +44,7 @@ public class BitBucketPPRPullRequestDeclinedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @Override
@@ -75,6 +73,7 @@ public class BitBucketPPRPullRequestDeclinedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Declined";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestMergedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestMergedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -43,11 +45,7 @@ public class BitBucketPPRPullRequestMergedActionFilter extends BitBucketPPRPullR
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -81,6 +79,7 @@ public class BitBucketPPRPullRequestMergedActionFilter extends BitBucketPPRPullR
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Merged";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerFilter.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -71,6 +72,7 @@ public class BitBucketPPRPullRequestTriggerFilter extends BitBucketPPRTriggerFil
   @Extension
   public static class FilterDescriptorImpl extends BitBucketPPRTriggerFilterDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Bitbucket Cloud Pull Request";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestTriggerMatcher.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2021, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestUpdatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestUpdatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.cloud;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -46,11 +48,7 @@ public class BitBucketPPRPullRequestUpdatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -89,6 +87,7 @@ public class BitBucketPPRPullRequestUpdatedActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRPullRequestActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Updated";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerActionDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerActionDescriptor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerActionFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -45,6 +45,6 @@ public abstract class BitBucketPPRPullRequestServerActionFilter
       BitBucketPPRAction pullRequestAction, BitBucketPPRHookEvent bitBucketEvent) throws IOException;
 
   public abstract boolean shouldSendApprove();
-  
+
   public abstract boolean shouldSendDecline();
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerApprovedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerApprovedActionFilter.java
@@ -24,8 +24,10 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.PULL_REQUEST_REVIEWER;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -54,11 +56,7 @@ public class BitBucketPPRPullRequestServerApprovedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @Override
@@ -85,6 +83,7 @@ public class BitBucketPPRPullRequestServerApprovedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Approved";
@@ -96,10 +95,7 @@ public class BitBucketPPRPullRequestServerApprovedActionFilter
   }
 
   private boolean allReviewersHaveApproved(BitBucketPPRAction pullRequestAction) {
-    return pullRequestAction.getPayload().getPullRequest().getParticipants().stream()
-            .filter(p -> isReviewer(p) && !p.getApproved())
-            .count()
-        == 0;
+    return pullRequestAction.getPayload().getPullRequest().getParticipants().stream().noneMatch(p -> isReviewer(p) && !p.getApproved());
   }
 
   private boolean isReviewer(BitBucketPPRParticipant pullRequestParticipant) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerCommentCreatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerCommentCreatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -47,20 +49,12 @@ public class BitBucketPPRPullRequestServerCommentCreatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
   public void setCommentFilter(String commentFilter) {
-    if (commentFilter == null) {
-      this.commentFilter = "";
-    } else {
-      this.commentFilter = commentFilter;
-    }
+      this.commentFilter = Objects.requireNonNullElse(commentFilter, "");
   }
 
   @Override
@@ -97,6 +91,7 @@ public class BitBucketPPRPullRequestServerCommentCreatedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Comment Created";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerCreatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerCreatedActionFilter.java
@@ -24,6 +24,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 import java.io.File;
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -46,7 +47,7 @@ public class BitBucketPPRPullRequestServerCreatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null || "".equals(allowedBranches)) {
+    if (allowedBranches == null || allowedBranches.isEmpty()) {
       this.allowedBranches = "";
     } else {
       this.allowedBranches = allowedBranches;
@@ -82,6 +83,7 @@ public class BitBucketPPRPullRequestServerCreatedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Created";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerDeclinedActionFilter.java
@@ -21,6 +21,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
@@ -32,6 +33,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 public class BitBucketPPRPullRequestServerDeclinedActionFilter
     extends BitBucketPPRPullRequestServerActionFilter {
@@ -43,11 +45,7 @@ public class BitBucketPPRPullRequestServerDeclinedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @Override
@@ -69,6 +67,7 @@ public class BitBucketPPRPullRequestServerDeclinedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Declined";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerMergedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerMergedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -45,11 +47,7 @@ public class BitBucketPPRPullRequestServerMergedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -76,6 +74,7 @@ public class BitBucketPPRPullRequestServerMergedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Merged";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerSourceUpdatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerSourceUpdatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -46,11 +48,7 @@ public class BitBucketPPRPullRequestServerSourceUpdatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -82,6 +80,7 @@ public class BitBucketPPRPullRequestServerSourceUpdatedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Source Branch of Pull Request Updated";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerTriggerFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerTriggerFilter.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import hudson.Extension;
@@ -61,6 +62,7 @@ public class BitBucketPPRPullRequestServerTriggerFilter extends BitBucketPPRTrig
   @Extension
   public static class FilterDescriptorImpl extends BitBucketPPRTriggerFilterDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Bitbucket Server Pull Request";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerUpdatedActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/server/BitBucketPPRPullRequestServerUpdatedActionFilter.java
@@ -23,7 +23,9 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.pullrequest.server
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -46,11 +48,7 @@ public class BitBucketPPRPullRequestServerUpdatedActionFilter
 
   @DataBoundSetter
   public void setAllowedBranches(String allowedBranches) {
-    if (allowedBranches == null) {
-      this.allowedBranches = "";
-    } else {
-      this.allowedBranches = allowedBranches;
-    }
+      this.allowedBranches = Objects.requireNonNullElse(allowedBranches, "");
   }
 
   @DataBoundSetter
@@ -82,6 +80,7 @@ public class BitBucketPPRPullRequestServerUpdatedActionFilter
   public static class ActionFilterDescriptorImpl
       extends BitBucketPPRPullRequestServerActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Updated";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryActionDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryActionDescriptor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryActionFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -48,7 +48,7 @@ public abstract class BitBucketPPRRepositoryActionFilter
   public abstract boolean shouldTriggerAlsoIfNothingChanged();
 
   public abstract boolean shouldSendApprove();
-  
+
   public boolean shouldSendDecline() {
     return false;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryPushActionFilter.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -125,6 +126,7 @@ public class BitBucketPPRRepositoryPushActionFilter extends BitBucketPPRReposito
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRRepositoryActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Bitbucket Cloud Push";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryTriggerFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryTriggerFilter.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
@@ -68,6 +69,7 @@ public class BitBucketPPRRepositoryTriggerFilter extends BitBucketPPRTriggerFilt
 
   @Extension
   public static class FilterDescriptorImpl extends BitBucketPPRTriggerFilterDescriptor {
+    @NonNull
     public String getDisplayName() {
       return "Push";
     }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryTriggerMatcher.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRRepositoryTriggerMatcher.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -37,7 +37,7 @@ public class BitBucketPPRRepositoryTriggerMatcher implements BitBucketPPREventTr
   @Override
   public boolean matchesAction(BitBucketPPRHookEvent bitbucketEvent,
       BitBucketPPRTriggerFilter triggerFilter) {
-    logger.log(Level.INFO, () -> "" + bitbucketEvent.toString());
+    logger.log(Level.INFO, bitbucketEvent::toString);
 
 
     logger.log(Level.FINE,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/repository/BitBucketPPRServerRepositoryPushActionFilter.java
@@ -24,6 +24,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.filter.repository;
 
 import static java.util.Objects.isNull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.cause.BitBucketPPRTriggerCause;
@@ -132,6 +133,7 @@ public class BitBucketPPRServerRepositoryPushActionFilter
   @Extension
   public static class ActionFilterDescriptorImpl extends BitBucketPPRRepositoryActionDescriptor {
 
+    @NonNull
     @Override
     public String getDisplayName() {
       return "Bitbucket Server Push";

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRHookEvent.java
@@ -48,9 +48,9 @@ import javax.naming.OperationNotSupportedException;
 /**
  * Extracts event and action from the event key sent by Bitbucket and verifies that they are
  * supported by the plugin.
- * 
+ *
  * @author cdelmonte
- * 
+ *
  */
 public class BitBucketPPRHookEvent {
   private String event;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRPayload.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRPayload.java
@@ -56,7 +56,7 @@ public interface BitBucketPPRPayload extends Serializable {
   default BitBucketPPRApproval getApproval() {
     return null;
   }
-  
+
   default BitBucketPPRComment getComment() {
     return null;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRPayloadFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/BitBucketPPRPayloadFactory.java
@@ -65,7 +65,7 @@ public class BitBucketPPRPayloadFactory {
     if (PULL_REQUEST_SERVER_EVENT.equals(bitbucketEvent.getEvent())) {
       return new BitBucketPPRServerPayload();
     }
-    
+
     if (DIAGNOSTICS.equals(bitbucketEvent.getEvent())) {
       return new BitBucketPPRServerPayload();
     }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRActor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRActor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,11 +20,13 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPRActor implements Serializable {
+  @Serial
   private static final long serialVersionUID = 4266599260720106245L;
 
   @SerializedName("display_name")

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRApproval.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRApproval.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,11 +20,13 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
 
 public class BitBucketPPRApproval implements Serializable {
+  @Serial
   private static final long serialVersionUID = -4394761268108854254L;
   private Date date;
   private BitBucketPPRActor user;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRBranch.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRBranch.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,9 +20,11 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRBranch implements Serializable {
+  @Serial
   private static final long serialVersionUID = -846166211765005578L;
   private String name;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRChange.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRChange.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,12 +20,14 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPRChange implements Serializable {
+  @Serial
   private static final long serialVersionUID = 7855401280893901392L;
 
   private boolean forced;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCloudPayload.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCloudPayload.java
@@ -23,7 +23,10 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 import com.google.gson.annotations.SerializedName;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 
+import java.io.Serial;
+
 public class BitBucketPPRCloudPayload implements BitBucketPPRPayload {
+  @Serial
   private static final long serialVersionUID = -3467640601880230847L;
 
   private BitBucketPPRPush push;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRComment.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRComment.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
 public class BitBucketPPRComment implements Serializable {
+  @Serial
   private static final long serialVersionUID = -8486598082322838487L;
 
   String id;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCommit.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRCommit.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,10 +20,12 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRCommit implements Serializable {
+  @Serial
   private static final long serialVersionUID = 795153370768402207L;
   private String hash;
   private String type;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRContent.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRContent.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRContent implements Serializable {
+  @Serial
   private static final long serialVersionUID = 970499631277905070L;
 
   String raw;
@@ -50,5 +52,5 @@ public class BitBucketPPRContent implements Serializable {
   public String toString() {
     return "BitBucketPPRContent [html=" + html + ", markup=" + markup + ", raw=" + raw + ", type="
         + type + "]";
-  } 
+  }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRDestination.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRDestination.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,9 +20,11 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRDestination implements Serializable {
+  @Serial
   private static final long serialVersionUID = -4298473654409288406L;
   private BitBucketPPRBranch branch;
   private BitBucketPPRCommit commit;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkActivity.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkActivity.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkActivity implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkApprove.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkApprove.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
  package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkApprove implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkComments.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkComments.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkComments implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkCommits.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkCommits.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkCommits implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDecline.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDecline.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkDecline implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDiff.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDiff.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkDiff implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDiffStat.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkDiffStat.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkDiffStat implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkHtml.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkHtml.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,6 +22,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
@@ -46,7 +47,8 @@ public class BitBucketPPRLinkHtml implements Serializable {
    * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
    * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    ******************************************************************************/
-  
+
+  @Serial
   private static final long serialVersionUID = -6887496731660740096L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkMerge.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkMerge.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
  package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkMerge implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkStatuses.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinkStatuses.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,9 +21,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRLinkStatuses implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinks.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRLinks.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,17 +20,19 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
 public class BitBucketPPRLinks implements Serializable {
+  @Serial
   private static final long serialVersionUID = 8607244117530188175L;
 
   private BitBucketPPRLinkHtml html;
 
   @SerializedName("self")
   private BitBucketPPRSelf selfProperty;
-  
+
   private BitBucketPPRLinkDecline decline;
   private BitBucketPPRLinkDiffStat diffstat;
   private BitBucketPPRLinkCommits commits;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRNew.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRNew.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,16 +20,18 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRNew implements Serializable {
+  @Serial
   private static final long serialVersionUID = -1128832514571843255L;
   private String type;
   private String name;
   private BitBucketPPRTarget target;
 
-  
+
   public BitBucketPPRTarget getTarget() {
     return target;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPROwner.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPROwner.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,11 +20,13 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPROwner implements Serializable {
+  @Serial
   private static final long serialVersionUID = 535433266823246782L;
 
   private String type;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRParticipant.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRParticipant.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,12 +20,14 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPRParticipant implements Serializable {
+  @Serial
   private static final long serialVersionUID = 7546251977007143345L;
   private String type;
   private BitBucketPPRActor user;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRProject.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRProject.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,10 +20,12 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRProject implements Serializable {
+  @Serial
   private static final long serialVersionUID = 2452121553837931076L;
   private BitBucketPPRLinks links;
   private String type;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPullRequest.java
@@ -20,6 +20,7 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -27,6 +28,7 @@ import java.util.List;
 import com.google.gson.annotations.SerializedName;
 
 public class BitBucketPPRPullRequest implements Serializable {
+  @Serial
   private static final long serialVersionUID = -530740975503014281L;
   private String id;
   private String title;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPush.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRPush.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,12 +20,14 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
 
 public class BitBucketPPRPush implements Serializable {
+  @Serial
   private static final long serialVersionUID = 5663991681801028868L;
   private List<BitBucketPPRChange> changes = new ArrayList<>();
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRRepository.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRRepository.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,11 +20,13 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPRRepository implements Serializable {
+  @Serial
   private static final long serialVersionUID = -5358049446460018798L;
   private String scm;
   private String website;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRSelf.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRSelf.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRSelf implements Serializable {
+  @Serial
   private static final long serialVersionUID = -9156939739440067961L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRSource.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRSource.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,10 +20,12 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRSource implements Serializable {
+  @Serial
   private static final long serialVersionUID = 8130236986503988538L;
   private BitBucketPPRBranch branch;
   private BitBucketPPRCommit commit;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRTarget.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/cloud/BitBucketPPRTarget.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,9 +20,11 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.cloud;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRTarget implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1L;
 
   private String hash;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerActor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerActor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018-2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,9 +22,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRServerActor implements Serializable {
+  @Serial
   private static final long serialVersionUID = -3776450706699542277L;
   private String name;
   private String emailAddress;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerChange.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerChange.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerChange implements Serializable {
+  @Serial
   private static final long serialVersionUID = 49898612250869977L;
   private BitBucketPPRServerRef ref;
   private String refId;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerClone.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerClone.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -20,10 +20,12 @@
  ******************************************************************************/
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerClone implements Serializable {
+  @Serial
   private static final long serialVersionUID = 8260609430213080172L;
   private String href;
   private String name;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerComment.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerComment.java
@@ -1,8 +1,10 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRServerComment implements Serializable{
+  @Serial
   private static final long serialVersionUID = -4778766502864544307L;
 
   String id;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerLinks.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerLinks.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,6 +22,7 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,7 @@ import com.google.gson.annotations.SerializedName;
 
 
 public class BitBucketPPRServerLinks implements Serializable {
+  @Serial
   private static final long serialVersionUID = -8908433977563131277L;
 
   @SerializedName("clone")

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerMergeCommit.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerMergeCommit.java
@@ -22,10 +22,12 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerMergeCommit implements Serializable {
+  @Serial
   private static final long serialVersionUID = -5347870725110898308L;
 
   private String id;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPRProperties.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPRProperties.java
@@ -22,10 +22,12 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerPRProperties implements Serializable {
+  @Serial
   private static final long serialVersionUID = -4327337466069004128L;
 
   private BitBucketPPRServerMergeCommit mergeCommit;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPayload.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPayload.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -7,6 +8,7 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
 
 
 public class BitBucketPPRServerPayload implements BitBucketPPRPayload {
+  @Serial
   private static final long serialVersionUID = -5088466617368578337L;
   private BitBucketPPRServerActor actor;
   private BitBucketPPRServerPullRequest pullRequest;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerProject.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerProject.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,11 +21,13 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import com.google.gson.annotations.SerializedName;
 
 public class BitBucketPPRServerProject implements Serializable {
+  @Serial
   private static final long serialVersionUID = -9104674017591226510L;
   private String key;
   private String id;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPullRequest.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerPullRequest.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018-2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,11 +22,13 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
 
 public class BitBucketPPRServerPullRequest implements Serializable {
+  @Serial
   private static final long serialVersionUID = -2700597086308321013L;
   private Long id;
   private Long version;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRef.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRef.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018-2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,10 +22,12 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerRef implements Serializable {
+  @Serial
   private static final long serialVersionUID = -8845585960950746623L;
   private String id;
   private String displayId;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRepository.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRepository.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018-2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,10 +22,12 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 import com.google.gson.annotations.SerializedName;
 
 public class BitBucketPPRServerRepository implements Serializable {
+  @Serial
   private static final long serialVersionUID = 2888690501986298784L;
   private String slug;
   private String id;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRepositoryRef.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerRepositoryRef.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2018-2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,9 +22,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class BitBucketPPRServerRepositoryRef implements Serializable {
+  @Serial
   private static final long serialVersionUID = 5693884607853431041L;
   private String id;
   private String displayId;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerSelf.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/model/server/BitBucketPPRServerSelf.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -21,10 +21,12 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.model.server;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 
 public class BitBucketPPRServerSelf implements Serializable {
+  @Serial
   private static final long serialVersionUID = 1433703376294956482L;
   private String href;
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRHandlerTemplate.java
@@ -62,7 +62,6 @@ public abstract class BitBucketPPRHandlerTemplate {
 
   // @todo: do we need it also for pushs?
   public void setApprovedOrDeclined() throws MalformedURLException {
-    return;
   }
 
   public abstract void setBuildStatusOnFinished() throws MalformedURLException;

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObservable.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObservable.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserver.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserverFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/observer/BitBucketPPRObserverFactory.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPayloadProcessorFactory.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPayloadProcessorFactory.java
@@ -60,7 +60,7 @@ public final class BitBucketPPRPayloadProcessorFactory {
           logger.info("Create BitBucketPPRRepositoryServerPayloadProcessor");
       return new BitBucketPPRRepositoryServerPayloadProcessor(probe, bitbucketEvent);
     }
-    
+
     // @todo: will be removed in version 3.0.0
     if (REPOSITORY_EVENT.equalsIgnoreCase(bitbucketEvent.getEvent())
         && REPOSITORY_POST.equalsIgnoreCase(bitbucketEvent.getAction())) {

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessor.java
@@ -21,8 +21,6 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.processor;
 
-import static java.util.Objects.nonNull;
-
 import io.jenkins.plugins.bitbucketpushandpullrequest.BitBucketPPRJobProbe;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPullRequestServerAction;
@@ -41,7 +39,7 @@ public class BitBucketPPRPullRequestServerPayloadProcessor extends BitBucketPPRP
   public BitBucketPPRPullRequestServerPayloadProcessor(
       @Nonnull BitBucketPPRJobProbe jobProbe, @Nonnull BitBucketPPRHookEvent bitbucketEvent) {
     super(jobProbe, bitbucketEvent);
-    logger.fine(() -> "Processing " + bitbucketEvent.toString());
+    logger.fine(() -> "Processing " + bitbucketEvent);
   }
 
   private BitBucketPPRAction buildActionForJobs(

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryCloudPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryCloudPayloadProcessor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryServerPayloadProcessor.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRRepositoryServerPayloadProcessor.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2020, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -26,7 +26,6 @@ import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPR
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
@@ -39,8 +38,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import hudson.Extension;
@@ -67,7 +66,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
   private static final BitBucketPPRPluginConfig globalConfig =
       BitBucketPPRPluginConfig.getInstance();
 
-  public void doIndex(@Nonnull StaplerRequest request, @Nonnull StaplerResponse response)
+  public void doIndex(@Nonnull StaplerRequest2 request, @Nonnull StaplerResponse2 response)
       throws IOException {
     // log request URL
     logger.log(Level.INFO, "Request URL: {0}", request.getRequestURI());
@@ -102,7 +101,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     }
   }
 
-  private void writeSuccessResponse(@Nonnull StaplerResponse response) throws IOException {
+  private void writeSuccessResponse(@Nonnull StaplerResponse2 response) throws IOException {
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_OK);
@@ -112,7 +111,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     out.close();
   }
 
-  private void writeFailResponse(@Nonnull StaplerResponse response) throws IOException {
+  private void writeFailResponse(@Nonnull StaplerResponse2 response) throws IOException {
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -122,7 +121,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     out.close();
   }
 
-  String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
+  String getInputStream(@Nonnull StaplerRequest2 request) throws IOException, InputStreamException {
     // replace The deprecated method toString(InputStream) from the type IOUtils
     String inputStream = IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
     if (StringUtils.isBlank(inputStream)) {
@@ -144,8 +143,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
   }
 
   static String decodeInputStream(
-      @Nonnull final String inputStream, @Nonnull final String contentType)
-      throws UnsupportedEncodingException {
+      @Nonnull final String inputStream, @Nonnull final String contentType) {
     String input = inputStream;
     if (StringUtils.startsWithIgnoreCase(
         contentType, BitBucketPPRConst.APPLICATION_X_WWW_FORM_URLENCODED)) {
@@ -157,7 +155,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     return input;
   }
 
-  BitBucketPPRHookEvent getBitbucketEvent(@Nonnull StaplerRequest request)
+  BitBucketPPRHookEvent getBitbucketEvent(@Nonnull StaplerRequest2 request)
       throws OperationNotSupportedException {
     String xEventHeader = request.getHeader(BitBucketPPRConst.X_EVENT_KEY);
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -21,32 +21,35 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
 
-import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.HOOK_URL;
-
-import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.annotation.Nonnull;
 import javax.naming.OperationNotSupportedException;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.kohsuke.stapler.StaplerRequest2;
-import org.kohsuke.stapler.StaplerResponse2;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.HOOK_URL;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
+import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.InputStreamException;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRPayload;
@@ -66,7 +69,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
   private static final BitBucketPPRPluginConfig globalConfig =
       BitBucketPPRPluginConfig.getInstance();
 
-  public void doIndex(@Nonnull StaplerRequest2 request, @Nonnull StaplerResponse2 response)
+  public void doIndex(@Nonnull StaplerRequest request, @Nonnull StaplerResponse response)
       throws IOException {
     // log request URL
     logger.log(Level.INFO, "Request URL: {0}", request.getRequestURI());
@@ -101,7 +104,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     }
   }
 
-  private void writeSuccessResponse(@Nonnull StaplerResponse2 response) throws IOException {
+  private void writeSuccessResponse(@Nonnull StaplerResponse response) throws IOException {
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_OK);
@@ -111,7 +114,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     out.close();
   }
 
-  private void writeFailResponse(@Nonnull StaplerResponse2 response) throws IOException {
+  private void writeFailResponse(@Nonnull StaplerResponse response) throws IOException {
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -121,7 +124,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     out.close();
   }
 
-  String getInputStream(@Nonnull StaplerRequest2 request) throws IOException, InputStreamException {
+  String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
     // replace The deprecated method toString(InputStream) from the type IOUtils
     String inputStream = IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
     if (StringUtils.isBlank(inputStream)) {
@@ -155,7 +158,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     return input;
   }
 
-  BitBucketPPRHookEvent getBitbucketEvent(@Nonnull StaplerRequest2 request)
+  BitBucketPPRHookEvent getBitbucketEvent(@Nonnull StaplerRequest request)
       throws OperationNotSupportedException {
     String xEventHeader = request.getHeader(BitBucketPPRConst.X_EVENT_KEY);
 

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbeTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbeTest.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * The MIT License
- * 
+ *
  * Copyright (C) 2019, CloudBees, Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
  * including without limitation the rights to use, copy, modify, merge, publish, distribute,
  * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
  * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -22,22 +22,11 @@
 
 package io.jenkins.plugins.bitbucketpushandpullrequest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 // import com.google.gson.Gson;
-import org.eclipse.jgit.transport.URIish;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
 
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTriggerTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRTriggerTest.java
@@ -17,10 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class BitBucketPPRTriggerTest {

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/api/BitBucketPPRBearerAuthorizationApiConsumerTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/client/api/BitBucketPPRBearerAuthorizationApiConsumerTest.java
@@ -8,9 +8,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.github.scribejava.core.model.Verb;

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/environment/BitBucketPPREnvironmentContributorTest.java
@@ -750,8 +750,8 @@ public class BitBucketPPREnvironmentContributorTest {
 
     assertEquals(
         "Bitbuckethook event and hockEvent property of cause object are the same.",
-        cause.getHookEvent(),
-        hookEventAction);
+            hookEventAction,
+            cause.getHookEvent());
   }
 
   @Test
@@ -773,12 +773,12 @@ public class BitBucketPPREnvironmentContributorTest {
 
     assertEquals(
         "Bitbuckethook event and hockEvent property of cause object are the same.",
-        cause.getHookEvent(),
-        hookEventAction);
+            hookEventAction,
+            cause.getHookEvent());
   }
 
   private BitBucketPPRPayload getCloudPayload(String res) {
-    return (BitBucketPPRPayload) getGenericPayload(res, BitBucketPPRCloudPayload.class);
+    return getGenericPayload(res, BitBucketPPRCloudPayload.class);
   }
 
   private BitBucketPPRServerPayload getServerPayload(String res) {

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/extension/dsl/BitBucketPPRHookJobDslExtensionTest.java
@@ -72,7 +72,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     j.buildAndAssertSuccess(seedJob);
   }
 
-  private String readDslScript(String path) throws Exception {
+  private String readDslScript(String path) {
     String script = null;
     try {
         ClassLoader classloader = Thread.currentThread().getContextClassLoader();
@@ -107,7 +107,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRRepositoryPushActionFilter");
+    assertEquals("BitBucketPPRRepositoryPushActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -133,7 +133,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRRepositoryPushActionFilter");
+    assertEquals("BitBucketPPRRepositoryPushActionFilter", dispNames.get(0));
     assertTrue(isToApprove);
   }
 
@@ -159,7 +159,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -186,7 +186,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(0));
     assertTrue(isToApprove);
   }
 
@@ -208,7 +208,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -229,7 +229,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentCreatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -250,7 +250,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentCreatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -271,7 +271,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentCreatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -292,7 +292,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentUpdatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -313,7 +313,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentUpdatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -334,7 +334,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentUpdatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -355,7 +355,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentDeletedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentDeletedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -376,7 +376,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCommentDeletedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCommentDeletedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -397,7 +397,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -422,7 +422,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -448,7 +448,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
     assertTrue(isToApprove);
   }
 
@@ -470,7 +470,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -495,7 +495,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -521,7 +521,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(0));
     assertTrue(isToApprove);
   }
 
@@ -544,7 +544,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestMergedActionFilter");
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -565,7 +565,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestDeclinedActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -590,7 +590,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestMergedActionFilter");
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -616,7 +616,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestDeclinedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -642,7 +642,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestMergedActionFilter");
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(0));
     assertTrue(isToApprove);
   }
 
@@ -672,9 +672,9 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(3, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(2));
   }
 
   @Test
@@ -709,11 +709,11 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(5, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestMergedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestDeclinedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestDeclinedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(4));
   }
 
   @Test
@@ -745,10 +745,10 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(4, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestMergedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(3));
   }
 
   @Test
@@ -769,7 +769,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
 
     /* Verify second job content */
     createdJob = (FreeStyleProject) j.getInstance().getItem("test-job2");
@@ -785,7 +785,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRRepositoryPushActionFilter");
+    assertEquals("BitBucketPPRRepositoryPushActionFilter", dispNames.get(0));
   }
 
   @Test
@@ -820,11 +820,11 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(5, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(4));
   }
 
   @Test
@@ -864,12 +864,12 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(6, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(5), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(5));
   }
 
   @Test
@@ -906,11 +906,11 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(5, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
   }
 
   @Test
@@ -966,19 +966,19 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(12, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(5), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(5));
 
-    assertEquals(dispNames.get(6), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(7), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(8), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(9), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(10), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(11), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(6));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(7));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(8));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(9));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(10));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(11));
   }
 
   @Test
@@ -988,7 +988,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1014,11 +1014,11 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(5, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(4));
   }
 
   @Test
@@ -1028,7 +1028,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1059,14 +1059,14 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(6, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(5), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(5));
   }
-  
+
   @Ignore
   @Test
   public void testDslServerAllPRAllowedBranchesWithApproveActionsPipeline() throws Exception {
@@ -1075,7 +1075,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1103,13 +1103,13 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(5, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
   }
-  
+
   @Test
   public void testDslServerAllPRUnfilteredAndAllowedBranchesActionsPipeline() throws Exception {
     /* Create seed job which will process DSL */
@@ -1117,7 +1117,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1161,17 +1161,17 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(11, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(4), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(5), "BitBucketPPRPullRequestServerCreatedActionFilter");
-    assertEquals(dispNames.get(6), "BitBucketPPRPullRequestServerUpdatedActionFilter");
-    assertEquals(dispNames.get(7), "BitBucketPPRPullRequestServerSourceUpdatedActionFilter");
-    assertEquals(dispNames.get(8), "BitBucketPPRPullRequestServerApprovedActionFilter");
-    assertEquals(dispNames.get(9), "BitBucketPPRPullRequestServerMergedActionFilter");
-    assertEquals(dispNames.get(10), "BitBucketPPRPullRequestServerDeclinedActionFilter");
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(3));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(4));
+    assertEquals("BitBucketPPRPullRequestServerCreatedActionFilter", dispNames.get(5));
+    assertEquals("BitBucketPPRPullRequestServerUpdatedActionFilter", dispNames.get(6));
+    assertEquals("BitBucketPPRPullRequestServerSourceUpdatedActionFilter", dispNames.get(7));
+    assertEquals("BitBucketPPRPullRequestServerApprovedActionFilter", dispNames.get(8));
+    assertEquals("BitBucketPPRPullRequestServerMergedActionFilter", dispNames.get(9));
+    assertEquals("BitBucketPPRPullRequestServerDeclinedActionFilter", dispNames.get(10));
   }
 
   @Ignore
@@ -1182,7 +1182,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1205,10 +1205,10 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(4, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestUpdatedActionFilter");
-    assertEquals(dispNames.get(2), "BitBucketPPRPullRequestMergedActionFilter");
-    assertEquals(dispNames.get(3), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(1));
+    assertEquals("BitBucketPPRPullRequestMergedActionFilter", dispNames.get(2));
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(3));
   }
 
   @Test
@@ -1218,7 +1218,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     /* Only one 'triggers{}' closure */
     assertEquals(1, triggers.size());
@@ -1229,7 +1229,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       assertEquals(1, tmp2.getTriggers().size());
       String tmpNname = tmp2.getTriggers().get(0).getActionFilter().getClass().getName();
       String dispName = tmpNname.substring(tmpNname.lastIndexOf(".") + 1);
-      assertEquals(dispName, "BitBucketPPRPullRequestDeclinedActionFilter");
+      assertEquals("BitBucketPPRPullRequestDeclinedActionFilter", dispName);
 
       BitBucketPPRPullRequestDeclinedActionFilter actionFilter = (BitBucketPPRPullRequestDeclinedActionFilter) tmp2.getTriggers().get(0).getActionFilter();
       assertEquals("**", actionFilter.allowedBranches);
@@ -1243,7 +1243,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
     /* Fetch the newly created job and check its trigger configuration */
     WorkflowJob createdJob = (WorkflowJob) j.getInstance().getItem("test-job");
     /* Go through all triggers to validate DSL */
-    PipelineTriggersJobProperty pipelineTriggers = (PipelineTriggersJobProperty) createdJob.getProperty(PipelineTriggersJobProperty.class);
+    PipelineTriggersJobProperty pipelineTriggers = createdJob.getProperty(PipelineTriggersJobProperty.class);
     Map<TriggerDescriptor, Trigger<?>> triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     List<String> dispNames = new ArrayList<>();
@@ -1260,7 +1260,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       isToApprove = tmp3.shouldSendApprove();
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRRepositoryPushActionFilter");
+    assertEquals("BitBucketPPRRepositoryPushActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 
@@ -1284,7 +1284,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestCreatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestCreatedActionFilter", dispNames.get(0));
 
     /* Verify second job content */
     createdJob = (FreeStyleProject) j.getInstance().getItem("test-job2");
@@ -1300,12 +1300,12 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestUpdatedActionFilter");
+    assertEquals("BitBucketPPRPullRequestUpdatedActionFilter", dispNames.get(0));
 
     /* Verify third job content */
     createdPipelineJob = (WorkflowJob) j.getInstance().getItem("test-job3");
     /* Go through all triggers to validate DSL */
-    pipelineTriggers = (PipelineTriggersJobProperty) createdPipelineJob.getProperty(PipelineTriggersJobProperty.class);
+    pipelineTriggers = createdPipelineJob.getProperty(PipelineTriggersJobProperty.class);
     triggers = pipelineTriggers.getTriggersMap();
     assertEquals(1, triggers.size());
     dispNames.clear();
@@ -1320,7 +1320,7 @@ public class BitBucketPPRHookJobDslExtensionTest {
       dispNames.add(dispName);
     }
     assertEquals(2, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRRepositoryPushActionFilter");
-    assertEquals(dispNames.get(1), "BitBucketPPRPullRequestCommentDeletedActionFilter");
+    assertEquals("BitBucketPPRRepositoryPushActionFilter", dispNames.get(0));
+    assertEquals("BitBucketPPRPullRequestCommentDeletedActionFilter", dispNames.get(1));
   }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestApprovedActionFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/filter/pullrequest/cloud/BitBucketPPRPullRequestApprovedActionFilterTest.java
@@ -7,16 +7,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import hudson.model.FreeStyleProject;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import io.jenkins.plugins.bitbucketpushandpullrequest.BitBucketPPRTrigger;
-import javaposse.jobdsl.plugin.ExecuteDslScripts;
-import javaposse.jobdsl.plugin.RemovedJobAction;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -255,7 +251,7 @@ public class BitBucketPPRPullRequestApprovedActionFilterTest {
     assertFalse(c.matches(allowedBranches, "origin/develop", null));
   }
 
-  private String readScript(String path) throws Exception {
+  private String readScript(String path) {
     String script = null;
     try {
       ClassLoader classloader = Thread.currentThread().getContextClassLoader();
@@ -291,7 +287,7 @@ public class BitBucketPPRPullRequestApprovedActionFilterTest {
     }
 
     assertEquals(1, dispNames.size());
-    assertEquals(dispNames.get(0), "BitBucketPPRPullRequestApprovedActionFilter");
+    assertEquals("BitBucketPPRPullRequestApprovedActionFilter", dispNames.get(0));
     assertFalse(isToApprove);
   }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestPayloadProcessorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestPayloadProcessorTest.java
@@ -23,11 +23,8 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.processor;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import hudson.ExtensionList;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,10 +34,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
-import org.mockito.MockedStatic.Verification;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import com.google.gson.Gson;

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessorTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/processor/BitBucketPPRPullRequestServerPayloadProcessorTest.java
@@ -137,9 +137,7 @@ public class BitBucketPPRPullRequestServerPayloadProcessorTest {
 
       Assertions.assertThrows(
           Exception.class,
-          () -> {
-            pullRequestPayloadProcessor.processPayload(payload, observable);
-          });
+          () -> pullRequestPayloadProcessor.processPayload(payload, observable));
     }
   }
 }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -24,10 +24,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import java.io.UnsupportedEncodingException;
+
 import java.util.stream.Stream;
 
-import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -45,8 +44,7 @@ class BitBucketPPRHookReceiverTest {
 
   @ParameterizedTest
   @MethodSource("paramsProvider")
-  void execDecodeImputStream(String inputStream, String contentType, String expected)
-      throws UnsupportedEncodingException {
+  void execDecodeImputStream(String inputStream, String contentType, String expected) {
     try (MockedStatic<ExtensionList> mocked = mockStatic(ExtensionList.class)) {
       mocked.when((Verification) ExtensionList.lookupSingleton(BitBucketPPRPluginConfig.class))
           .thenReturn(mock(BitBucketPPRPluginConfig.class));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Updated the repository link utilized for downloading plugin dependencies during a Maven build to location that worked in previous version (3.2.0).  The latest commit repository link points to location that no longer exists causing the build to fail.  The fail can be seen in the CodeQL check.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
