### PR TITLE
Fix shared-library false positive for Pipeline @libs checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Bug Fixes
+* **Fix shared-library false positive for Pipeline libraries checked out under `@libs`** - The plugin now records, at checkout time, the role each `GitSCM` plays in a build (Pipeline shared library vs. explicit checkout) and excludes from webhook matching only repositories that were used *exclusively* as a library. This preserves the multi-remote behaviour from #378, the legacy filter from #281 / #196, and triggers for jobs that use the same repository both as a library and as an explicit checkout. Note: protection starts after a job has run at least once under this version. Fixes #380.
+
 ## 3.3.5 (2026-05-12)
 
 ### Bug Fixes

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
@@ -22,12 +22,14 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest;
 
 import hudson.model.Job;
+import hudson.model.Run;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRAction;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.TriggerNotSetException;
 import io.jenkins.plugins.bitbucketpushandpullrequest.model.BitBucketPPRHookEvent;
@@ -38,7 +40,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -126,6 +127,19 @@ public class BitBucketPPRJobProbe {
 
     jobTrigger.scmTriggerItem.ifPresent(it -> it.getSCMs().forEach(scm -> {
 
+      // Single-job mode does not match webhook URLs against the job's SCM (the job is
+      // pre-selected by the caller), but the Pipeline-shared-library exclusion still
+      // applies: a library SCM that happens to be in this job's getSCMs() must not
+      // become an onPost target (issue #380).
+      if (scm instanceof GitSCM && isExcludedAsPipelineLibrary(job, (GitSCM) scm)) {
+        if (logger.isLoggable(Level.FINE)) {
+          logger.log(Level.FINE,
+              "Skipping SCM for single-job {0}: classified as a Pipeline shared library.",
+              job.getName());
+        }
+        return;
+      }
+
       if (!scmTriggered.contains(scm)) {
         scmTriggered.add(scm);
 
@@ -162,13 +176,34 @@ public class BitBucketPPRJobProbe {
         return;
       }
 
-      Predicate<URIish> checkSCM = url -> scm instanceof GitSCM && !isLibrarySCM(scm) && matchGitScm(scm, url);
+      if (!(scm instanceof GitSCM)) {
+        return;
+      }
+      GitSCM gitScm = (GitSCM) scm;
 
-      if (remotes.stream().anyMatch(checkSCM) && !scmTriggered.contains(scm)) {
-        scmTriggered.add(scm);
+      // Filter ordering: match the webhook URL against the SCM FIRST. The library
+      // checks depend only on (job, scm) — running them inside the per-URI stream
+      // would re-evaluate them for every URI in `remotes`, and running them at all
+      // for jobs whose SCM URL does not even overlap the webhook payload wastes work
+      // on every unrelated job in a large Jenkins instance.
+      if (remotes.stream().noneMatch(url -> matchGitScm(gitScm, url))) {
+        if (logger.isLoggable(Level.FINE)) {
+          logger.log(Level.FINE, "{0} SCM doesn't match remote repo {1}.",
+              new Object[] {job.getName(),
+                  remotes.stream().map(URIish::toString).collect(Collectors.joining(", "))});
+        }
+        return;
+      }
+
+      if (isExcludedAsPipelineLibrary(job, gitScm)) {
+        return;
+      }
+
+      if (!scmTriggered.contains(gitScm)) {
+        scmTriggered.add(gitScm);
 
         try {
-          jobTrigger.bitbucketTrigger.onPost(bitbucketEvent, bitbucketAction, scm, observable);
+          jobTrigger.bitbucketTrigger.onPost(bitbucketEvent, bitbucketAction, gitScm, observable);
           return;
 
         } catch (Exception e) {
@@ -176,8 +211,11 @@ public class BitBucketPPRJobProbe {
         }
       }
 
-      logger.log(Level.FINE, "{0} SCM doesn't match remote repo {1} or it was already triggered.",
-          new Object[] { job.getName(), remotes.stream().map(URIish::toString).collect(Collectors.joining(", ")) });
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE, "{0} SCM was already triggered for remote repo {1}.",
+            new Object[] {job.getName(),
+                remotes.stream().map(URIish::toString).collect(Collectors.joining(", "))});
+      }
 
     }));
   }
@@ -242,6 +280,34 @@ public class BitBucketPPRJobProbe {
   }
 
 
+  // Two-counter scan budget:
+  //
+  // RECENT_BUILDS_WINDOW bounds the *semantic* lookback — how many builds with
+  // an informative-but-UNKNOWN verdict we are willing to look past before
+  // giving up. Pre-upgrade builds (action == null) and in-progress builds are
+  // skipped and do NOT consume this budget; otherwise their noise would mask
+  // the first informative verdict.
+  //
+  // MAX_BUILDS_TO_SCAN bounds the *operational* lookback — the absolute
+  // number of Run objects the scan will walk through, regardless of their
+  // state. Pre-upgrade and in-progress builds do not consume the semantic
+  // budget, but they still consume MAX_BUILDS_TO_SCAN. A job with thousands of
+  // pre-upgrade builds would otherwise let the semantic counter alone walk
+  // arbitrarily far; this cap keeps the per-webhook cost finite.
+  private static final int RECENT_BUILDS_WINDOW = 10;
+  private static final int MAX_BUILDS_TO_SCAN = 50;
+
+  // Together with isRecordedOnlyAsPipelineLibrary, this method participates in
+  // the Pipeline-shared-library exclusion: both gates are always evaluated and
+  // either returning true skips the SCM. isLibrarySCM is the older, narrower
+  // heuristic (single-remote with a non-origin remote name); it is retained
+  // because it still covers cases the listener cannot: builds executed before
+  // this plugin version (no recorded action) and jobs whose recent builds did
+  // not exercise the library code path (action absent from the entire window).
+  // Do NOT remove this method: deleting it would silently reintroduce #281 for
+  // those jobs. Do NOT extend it either — remote names are not a reliable
+  // signal for Pipeline shared libraries (see #378 and #380); for new shapes,
+  // extend BitBucketPPRSCMCheckoutListener / BitBucketPPRPipelineLibrarySCMAction.
   private boolean isLibrarySCM(SCM scm) {
     if (!(scm instanceof GitSCM)) {
       return false;
@@ -260,9 +326,74 @@ public class BitBucketPPRJobProbe {
 
     String remoteName = repositories.get(0).getName();
     if (remoteName != null && !remoteName.isEmpty() && !"origin".equals(remoteName)) {
-      logger.log(Level.FINE, "Skipping SCM with remote name ''{0}'' as it appears to be a shared library.",
-          remoteName);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.FINE,
+            "Skipping SCM with remote name ''{0}'' as it appears to be a shared library.",
+            remoteName);
+      }
       return true;
+    }
+    return false;
+  }
+
+  // Returns true if `scm` is recognised as a Pipeline shared library for `job`,
+  // either by the legacy remote-name heuristic (isLibrarySCM) or by an entry
+  // recorded ONLY as a library (not also as an explicit checkout) by
+  // BitBucketPPRSCMCheckoutListener within the recent-builds window.
+  private boolean isExcludedAsPipelineLibrary(Job<?, ?> job, GitSCM scm) {
+    return isLibrarySCM(scm) || isRecordedOnlyAsPipelineLibrary(job, scm);
+  }
+
+  // Scans recent builds for an authoritative verdict from
+  // BitBucketPPRPipelineLibrarySCMAction.classify(scm). The scan stops on the
+  // FIRST build whose classify is informative:
+  //   ONLY_LIBRARY         -> return true  (skip the SCM)
+  //   NON_LIBRARY_OR_MIXED -> return false (do NOT skip — the most recent build
+  //                                         with an opinion says the SCM is
+  //                                         consumed as a real source too)
+  //   UNKNOWN              -> keep scanning earlier builds
+  //
+  // The tri-state is what prevents an older "library-only" snapshot from
+  // shadowing a newer "library+explicit" snapshot — collapsing to a boolean
+  // would return true on the older entry and silently filter a webhook the
+  // user expects to fire (issue #380 corollary).
+  //
+  // In-progress builds are skipped: their action reflects whatever checkouts
+  // have completed so far and can return ONLY_LIBRARY prematurely (e.g. the
+  // library was checked out at the top of the Jenkinsfile but the explicit
+  // checkout step has not run yet). Pre-upgrade builds (action == null)
+  // contribute nothing and also do not consume the semantic window.
+  //
+  // Two budgets bound the walk: see RECENT_BUILDS_WINDOW / MAX_BUILDS_TO_SCAN.
+  private boolean isRecordedOnlyAsPipelineLibrary(Job<?, ?> job, GitSCM scm) {
+    int informativeRemaining = RECENT_BUILDS_WINDOW;
+    int scannedRemaining = MAX_BUILDS_TO_SCAN;
+    for (Run<?, ?> run = job.getLastBuild();
+         run != null && informativeRemaining > 0 && scannedRemaining > 0;
+         run = run.getPreviousBuild(), scannedRemaining--) {
+      if (run.isBuilding()) {
+        continue;
+      }
+      BitBucketPPRPipelineLibrarySCMAction action =
+          run.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+      if (action == null) {
+        continue;
+      }
+      switch (action.classify(scm)) {
+        case ONLY_LIBRARY:
+          if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE,
+                "Skipping SCM {0} as it was recorded exclusively as a Pipeline shared library on build {1}.",
+                new Object[] {scm.getKey(), run.getFullDisplayName()});
+          }
+          return true;
+        case NON_LIBRARY_OR_MIXED:
+          return false;
+        case UNKNOWN:
+        default:
+          informativeRemaining--;
+          break;
+      }
     }
     return false;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRSCMCheckoutListener.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRSCMCheckoutListener.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2025, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.SCMListener;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.SCM;
+import hudson.scm.SCMRevisionState;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import jenkins.model.ParameterizedJobMixIn;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+
+/**
+ * Records, at checkout time, the role each Git checkout played in a build — Pipeline shared
+ * library vs. ordinary (non-library) checkout — so that {@link BitBucketPPRJobProbe} can later
+ * skip webhook events for repositories that the build only consumed as a library (issue #380),
+ * while still letting webhooks trigger when the same repository was also pulled in via an explicit
+ * {@code checkout} step.
+ *
+ * <p>A checkout is identified as a shared-library checkout by the workspace layout used by
+ * {@code pipeline-groovy-lib}'s legacy {@code SCMRetriever}:
+ * {@code <job-workspace>@libs/<directoryName>}. The {@code @libs} marker must be followed by a
+ * path separator and at least one more character; a path that merely ends in {@code @libs} (no
+ * trailing segment) is not recognised, since that shape collides with user-chosen job names
+ * ending in {@code @libs}.
+ *
+ * <p>Scope: the listener is global (Jenkins wires {@link SCMListener}s in before this plugin
+ * knows which jobs care), but it only records checkouts for jobs that have a
+ * {@link BitBucketPPRTrigger} configured. Builds on unrelated jobs are not annotated, so
+ * uninstalling the plugin does not leave orphan action references in their {@code build.xml}.
+ *
+ * <p>Known limitations:
+ *
+ * <ul>
+ *   <li>Clone-mode shared libraries (workspace path
+ *       {@code <build-root>/libs/<directoryName>}) are not detected on distributed builds,
+ *       because the build-root is a controller-side path while the checkout workspace lives on
+ *       the agent.
+ *   <li>Triggers defined inside the {@code Jenkinsfile} via {@code properties { pipelineTriggers
+ *       ... }} are not present on the job at the time of the very first checkout, so the very
+ *       first build under this plugin version may not be protected for that job; subsequent
+ *       builds are. For multibranch projects this means each newly-discovered branch is
+ *       unprotected on its first build (the legacy remote-name heuristic in
+ *       {@code BitBucketPPRJobProbe.isLibrarySCM} still catches the non-origin variant).
+ * </ul>
+ */
+@Extension
+public class BitBucketPPRSCMCheckoutListener extends SCMListener {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(BitBucketPPRSCMCheckoutListener.class.getName());
+
+  // Pipeline-groovy-lib's legacy retriever checks shared libraries out under
+  // <job-workspace>@libs/<directoryName>[/...]. The `@libs` token must be
+  // followed by a path separator AND at least one more character; a bare
+  // `...@libs` suffix is NOT matched (collides with user job names ending in @libs).
+  private static final Pattern PIPELINE_LIBRARY_WORKSPACE =
+      Pattern.compile(".*@libs[/\\\\].+");
+
+  @Override
+  public void onCheckout(
+      Run<?, ?> build,
+      SCM scm,
+      FilePath workspace,
+      TaskListener listener,
+      File changelogFile,
+      SCMRevisionState pollingBaseline) {
+    if (build == null || workspace == null || !(scm instanceof GitSCM)) {
+      return;
+    }
+    if (!jobUsesBitBucketTrigger(build.getParent())) {
+      return;
+    }
+
+    GitSCM gitScm = (GitSCM) scm;
+    boolean asLibrary = isPipelineLibraryWorkspace(workspace);
+
+    // Extract URIs ONCE, before allocating/attaching the action, so that a
+    // malformed GitSCM does not leave an empty action behind on a build that
+    // legitimately had no recordable URIs — and so that the action is only
+    // touched in one place (here), keeping the GitSCM access path trivially
+    // auditable.
+    List<URIish> uris;
+    try {
+      uris = collectUris(gitScm);
+    } catch (RuntimeException e) {
+      LOGGER.log(
+          Level.WARNING,
+          "Failed to extract URIs from GitSCM on build "
+              + build.getFullDisplayName()
+              + "; continuing without library-filter protection for this checkout",
+          e);
+      return;
+    }
+    if (uris.isEmpty()) {
+      return;
+    }
+
+    BitBucketPPRPipelineLibrarySCMAction action;
+    // Synchronize on the Run so concurrent onCheckout calls (parallel-stage
+    // checkouts) cannot both pass the null-check and install duplicate actions —
+    // Run.getAction(Class) would then return only the first, dropping every URI
+    // recorded into the second instance.
+    synchronized (build) {
+      action = build.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+      if (action == null) {
+        action = new BitBucketPPRPipelineLibrarySCMAction();
+        build.addAction(action);
+      }
+    }
+
+    if (asLibrary) {
+      action.recordLibrary(uris);
+    } else {
+      action.recordNonLibrary(uris);
+    }
+
+    if (LOGGER.isLoggable(Level.FINE)) {
+      LOGGER.log(
+          Level.FINE,
+          "Recorded {0} checkout for SCM {1} on build {2}",
+          new Object[] {asLibrary ? "Pipeline library" : "non-library",
+              gitScm.getKey(), build.getFullDisplayName()});
+    }
+  }
+
+  /**
+   * Returns true if {@code job} has a {@link BitBucketPPRTrigger} configured. Mirrors the probe's
+   * {@code getBitBucketTrigger(job)}: jobs the probe would process are exactly the jobs the
+   * listener records for.
+   */
+  private static boolean jobUsesBitBucketTrigger(Job<?, ?> job) {
+    if (!(job instanceof ParameterizedJobMixIn.ParameterizedJob<?, ?>)) {
+      return false;
+    }
+    return ((ParameterizedJobMixIn.ParameterizedJob<?, ?>) job)
+        .getTriggers().values().stream().anyMatch(BitBucketPPRTrigger.class::isInstance);
+  }
+
+  static boolean isPipelineLibraryWorkspace(FilePath workspace) {
+    if (workspace == null) {
+      return false;
+    }
+    String remote = workspace.getRemote();
+    return remote != null && PIPELINE_LIBRARY_WORKSPACE.matcher(remote).matches();
+  }
+
+  private static List<URIish> collectUris(GitSCM scm) {
+    List<URIish> out = new ArrayList<>();
+    for (RemoteConfig repo : scm.getRepositories()) {
+      List<URIish> uris = repo.getURIs();
+      if (uris == null) {
+        continue;
+      }
+      for (URIish uri : uris) {
+        if (uri != null) {
+          out.add(uri);
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPipelineLibrarySCMAction.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPipelineLibrarySCMAction.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2025, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.action;
+
+import hudson.model.InvisibleAction;
+import hudson.plugins.git.GitSCM;
+import hudson.plugins.git.GitStatus;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+
+/**
+ * Records, on a {@link hudson.model.Run}, the Git remotes seen by the build, split by the role
+ * they played:
+ *
+ * <ul>
+ *   <li>{@code libraryRemotes} — checkouts done under a Pipeline shared-library workspace
+ *       ({@code <job-workspace>@libs/<dir>}, recognised by
+ *       {@code BitBucketPPRSCMCheckoutListener}).
+ *   <li>{@code nonLibraryRemotes} — every other Git checkout the build performed (the job's main
+ *       source SCM, explicit {@code checkout} steps, etc.).
+ * </ul>
+ *
+ * <p>The probe consults {@link #classify(GitSCM)} to decide whether to skip a webhook match.
+ * The result is tri-state ({@link Classification#ONLY_LIBRARY}, {@link
+ * Classification#NON_LIBRARY_OR_MIXED}, {@link Classification#UNKNOWN}) so the probe can
+ * distinguish "this build proves the SCM is exclusively a library" from "this build has no
+ * opinion" — the latter is what enables the scan-window logic to fall back to an older build
+ * without having a newer build's NON_LIBRARY verdict silently shadowed by an older
+ * ONLY_LIBRARY verdict.
+ *
+ * <p>Stored URIs are sanitized to host + path: that is the only subset {@link
+ * GitStatus#looselyMatches(URIish, URIish)} actually consults, and we deliberately do not
+ * duplicate scheme/user/password into a separate action on the Run.
+ *
+ * <p>Thread-safety: writes happen from build executor threads (parallel-stage library/checkout
+ * steps fire concurrently) while reads happen from the webhook HTTP dispatch thread; all methods
+ * that touch the internal lists are {@code synchronized} on the action instance.
+ */
+public class BitBucketPPRPipelineLibrarySCMAction extends InvisibleAction {
+
+  /**
+   * Per-build verdict on whether a queried {@link GitSCM} was exclusively a Pipeline shared
+   * library in this build, also a real (non-library) checkout, or simply not seen.
+   *
+   * <p>The probe uses this to walk the recent-builds window: an {@code UNKNOWN} verdict means
+   * "this build has nothing to say, keep scanning"; the other two are authoritative.
+   */
+  public enum Classification {
+    /** SCM matches a library remote and does NOT also match any non-library remote. */
+    ONLY_LIBRARY,
+    /** SCM matches a non-library remote, or is multi-remote (never a library by construction). */
+    NON_LIBRARY_OR_MIXED,
+    /** This build has not seen any of the SCM's URIs in either role. */
+    UNKNOWN
+  }
+
+  private final List<URIish> libraryRemotes = new ArrayList<>();
+  private final List<URIish> nonLibraryRemotes = new ArrayList<>();
+
+  /** Records the given URIs as Pipeline shared-library checkouts. */
+  public synchronized void recordLibrary(Iterable<URIish> uris) {
+    record(uris, libraryRemotes);
+  }
+
+  /** Records the given URIs as non-library (explicit) checkouts. */
+  public synchronized void recordNonLibrary(Iterable<URIish> uris) {
+    record(uris, nonLibraryRemotes);
+  }
+
+  /**
+   * Returns this build's verdict on {@code scm}:
+   *
+   * <ul>
+   *   <li>{@link Classification#NON_LIBRARY_OR_MIXED} when {@code scm} is multi-remote (by
+   *       construction not a library — preserves #378) OR any of its URIs matches a recorded
+   *       non-library URI;
+   *   <li>{@link Classification#ONLY_LIBRARY} when at least one URI matches a library URI AND no
+   *       URI matches a non-library URI;
+   *   <li>{@link Classification#UNKNOWN} when none of the URIs has been seen in this build.
+   * </ul>
+   *
+   * <p>This three-valued return is what allows the probe to honour the most-recent build's
+   * verdict instead of OR-ing across the window: a more recent build that returns
+   * {@code NON_LIBRARY_OR_MIXED} must shadow an older build that returned {@code ONLY_LIBRARY}.
+   *
+   * <p>Scoping: the multi-remote shortcut returns {@code NON_LIBRARY_OR_MIXED} unconditionally,
+   * including when none of the queried URIs is actually in either recorded list. That is
+   * intentional but only meaningful in the probe's call chain — {@code classify} is consulted
+   * AFTER {@code BitBucketPPRJobProbe.matchGitScm} has already established that {@code scm}'s
+   * URL overlaps the webhook payload, so an irrelevant multi-remote SCM never reaches this
+   * method in production. The shortcut is what lets the probe's scan stop at the most recent
+   * "this is a real source" verdict instead of regressing to an older library-only entry for
+   * one of the multi-remote URIs.
+   */
+  public synchronized Classification classify(GitSCM scm) {
+    if (scm == null) {
+      return Classification.UNKNOWN;
+    }
+    List<RemoteConfig> repos = scm.getRepositories();
+    if (repos.size() != 1) {
+      // Multi-remote GitSCM is by construction a real source SCM, never a library
+      // (preserves the invariant from #378). Returning NON_LIBRARY_OR_MIXED — rather
+      // than UNKNOWN — ensures the probe's scan stops here and does not regress to
+      // an older build's ONLY_LIBRARY verdict for a remote that coincides with one
+      // of the multi-remote URIs.
+      return Classification.NON_LIBRARY_OR_MIXED;
+    }
+    List<URIish> uris = repos.get(0).getURIs();
+    if (uris == null) {
+      return Classification.UNKNOWN;
+    }
+    boolean seenAsLibrary = false;
+    for (URIish queried : uris) {
+      if (queried == null) {
+        continue;
+      }
+      if (matchesAny(queried, nonLibraryRemotes)) {
+        return Classification.NON_LIBRARY_OR_MIXED;
+      }
+      if (matchesAny(queried, libraryRemotes)) {
+        seenAsLibrary = true;
+      }
+    }
+    return seenAsLibrary ? Classification.ONLY_LIBRARY : Classification.UNKNOWN;
+  }
+
+  private void record(Iterable<URIish> uris, List<URIish> target) {
+    if (uris == null) {
+      return;
+    }
+    for (URIish uri : uris) {
+      if (uri == null) {
+        continue;
+      }
+      URIish sanitized = sanitize(uri);
+      if (!matchesAny(sanitized, target)) {
+        target.add(sanitized);
+      }
+    }
+  }
+
+  // GitStatus.looselyMatches consults only host and normalized path; strip the
+  // rest so the Run action does not duplicate credentials or scheme that we do
+  // not actually need to do the comparison.
+  private static URIish sanitize(URIish uri) {
+    return uri.setUser(null).setPass(null).setScheme(null).setPort(-1);
+  }
+
+  private static boolean matchesAny(URIish uri, List<URIish> list) {
+    for (URIish stored : list) {
+      if (GitStatus.looselyMatches(stored, uri)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbeTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbeTest.java
@@ -26,12 +26,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.SCM;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.util.List;
 import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -48,6 +53,27 @@ class BitBucketPPRJobProbeTest {
     Method method = BitBucketPPRJobProbe.class.getDeclaredMethod("isLibrarySCM", SCM.class);
     method.setAccessible(true);
     return (boolean) method.invoke(probe, scm);
+  }
+
+  private boolean invokeIsRecordedOnlyAsPipelineLibrary(
+      BitBucketPPRJobProbe probe, Job<?, ?> job, GitSCM scm) throws Exception {
+    Method method =
+        BitBucketPPRJobProbe.class.getDeclaredMethod(
+            "isRecordedOnlyAsPipelineLibrary", Job.class, GitSCM.class);
+    method.setAccessible(true);
+    return (boolean) method.invoke(probe, job, scm);
+  }
+
+  private GitSCM mockGitScmWithUrl(String url) throws URISyntaxException {
+    GitSCM scm = mock(GitSCM.class);
+    RemoteConfig remote = mock(RemoteConfig.class);
+    when(remote.getURIs()).thenReturn(List.of(new URIish(url)));
+    when(scm.getRepositories()).thenReturn(List.of(remote));
+    return scm;
+  }
+
+  private static List<URIish> uris(String url) throws URISyntaxException {
+    return List.of(new URIish(url));
   }
 
   @Test
@@ -142,6 +168,266 @@ class BitBucketPPRJobProbeTest {
 
       assertFalse(invokeIsLibrarySCM(probe, gitScm),
           "Multi-remote GitSCM must not be classified as a shared library solely from remote names (issue #378)");
+    }
+  }
+
+  // Regression test for issue #380: an SCM recorded exclusively as a Pipeline
+  // shared library is skipped by the probe even when the remote is named "origin".
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryTrueWhenActionMatchesScmAsLibraryOnly()
+      throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+      action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      Run<?, ?> lastBuild = mock(Run.class);
+      when(lastBuild.isBuilding()).thenReturn(false);
+      when(lastBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(action);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> lastBuild);
+
+      // Webhook URL via a different scheme; GitStatus.looselyMatches still matches.
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/repo.git");
+      assertTrue(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm));
+    }
+  }
+
+  // Critical regression test: when the same repository was checked out BOTH as
+  // a shared library AND as an explicit checkout in the same build, the probe
+  // must NOT classify it as "library only" — the explicit-checkout half must
+  // still react to pushes for that repo.
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryFalseWhenSameRepoIsAlsoExplicitlyCheckedOut()
+      throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+      action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+      action.recordNonLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      Run<?, ?> lastBuild = mock(Run.class);
+      when(lastBuild.isBuilding()).thenReturn(false);
+      when(lastBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(action);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> lastBuild);
+
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm),
+          "Repo present as BOTH library and explicit checkout must not be classified as library-only");
+    }
+  }
+
+  // CRITICAL regression test for the tri-state scan: the most recent build that
+  // has an authoritative verdict (NON_LIBRARY_OR_MIXED) must veto any older
+  // build that recorded the same repository as library-only. A boolean
+  // "isOnlyLibrary across the window" check would wrongly return true here.
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryFalseWhenLatestBuildIsMixedAndPreviousIsLibraryOnly()
+      throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      // Previous build: RepoD was only loaded as a library.
+      BitBucketPPRPipelineLibrarySCMAction previousAction =
+          new BitBucketPPRPipelineLibrarySCMAction();
+      previousAction.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      // Latest build: the Jenkinsfile now ALSO does an explicit checkout of RepoD.
+      BitBucketPPRPipelineLibrarySCMAction latestAction =
+          new BitBucketPPRPipelineLibrarySCMAction();
+      latestAction.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+      latestAction.recordNonLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      Run<?, ?> previousBuild = mock(Run.class);
+      when(previousBuild.isBuilding()).thenReturn(false);
+      when(previousBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class))
+          .thenReturn(previousAction);
+      when(previousBuild.getPreviousBuild()).thenAnswer(inv -> null);
+
+      Run<?, ?> latestBuild = mock(Run.class);
+      when(latestBuild.isBuilding()).thenReturn(false);
+      when(latestBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class))
+          .thenReturn(latestAction);
+      Run<?, ?> previousAsRaw = previousBuild;
+      when(latestBuild.getPreviousBuild()).thenAnswer(inv -> previousAsRaw);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> latestBuild);
+
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm),
+          "Latest build's NON_LIBRARY_OR_MIXED verdict must veto older library-only entries");
+    }
+  }
+
+  // In-progress builds reflect partial state (the library was already checked
+  // out, the explicit step has not run yet). The scan must skip them and use
+  // the most recent COMPLETED build's verdict instead.
+  @Test
+  void testIsRecordedOnlyAsPipelineLibrarySkipsInProgressBuilds() throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      // In-progress build: library recorded, explicit not yet (partial state).
+      BitBucketPPRPipelineLibrarySCMAction partial = new BitBucketPPRPipelineLibrarySCMAction();
+      partial.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      // Completed earlier build: full mixed verdict.
+      BitBucketPPRPipelineLibrarySCMAction completed = new BitBucketPPRPipelineLibrarySCMAction();
+      completed.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+      completed.recordNonLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      Run<?, ?> earlierBuild = mock(Run.class);
+      when(earlierBuild.isBuilding()).thenReturn(false);
+      when(earlierBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(completed);
+      when(earlierBuild.getPreviousBuild()).thenAnswer(inv -> null);
+
+      Run<?, ?> inProgress = mock(Run.class);
+      when(inProgress.isBuilding()).thenReturn(true);
+      when(inProgress.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(partial);
+      Run<?, ?> earlierAsRaw = earlierBuild;
+      when(inProgress.getPreviousBuild()).thenAnswer(inv -> earlierAsRaw);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> inProgress);
+
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm),
+          "Probe must skip in-progress build's partial verdict and honour the completed one");
+    }
+  }
+
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryFalseWhenNoLastBuild() throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> null);
+
+      GitSCM scm = mockGitScmWithUrl("ssh://git@host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, scm));
+    }
+  }
+
+  // The probe scans a window of recent builds, not only lastBuild — if the
+  // most recent build had no action (e.g. pre-upgrade build) but a previous
+  // build did, the filter still applies.
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryScansPreviousBuildsWhenLastBuildHasNoAction()
+      throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+      action.recordLibrary(uris("ssh://git@host.example.com/org/lib.git"));
+
+      Run<?, ?> earlierBuild = mock(Run.class);
+      when(earlierBuild.isBuilding()).thenReturn(false);
+      when(earlierBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(action);
+      when(earlierBuild.getPreviousBuild()).thenAnswer(inv -> null);
+
+      Run<?, ?> lastBuild = mock(Run.class);
+      when(lastBuild.isBuilding()).thenReturn(false);
+      when(lastBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(null);
+      Run<?, ?> earlierAsRaw = earlierBuild;
+      when(lastBuild.getPreviousBuild()).thenAnswer(inv -> earlierAsRaw);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> lastBuild);
+
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/lib.git");
+      assertTrue(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm),
+          "Multi-build scan should find a recorded library on a previous build");
+    }
+  }
+
+  // Operational cap: a long chain of null-action builds (e.g. a job upgraded
+  // with thousands of pre-listener builds in its history) must not let the
+  // scan walk indefinitely. After MAX_BUILDS_TO_SCAN visits the scan stops
+  // even if an authoritative verdict is sitting just past the cap.
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryStopsAtMaxBuildsToScan() throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      // The 51st build (just past the operational cap of 50) carries the
+      // ONLY_LIBRARY verdict, but the scan must never reach it.
+      BitBucketPPRPipelineLibrarySCMAction libraryAction =
+          new BitBucketPPRPipelineLibrarySCMAction();
+      libraryAction.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+      Run<?, ?> beyondCap = mock(Run.class);
+      when(beyondCap.isBuilding()).thenReturn(false);
+      when(beyondCap.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(libraryAction);
+      when(beyondCap.getPreviousBuild()).thenAnswer(inv -> null);
+
+      // Chain 50 null-action pre-upgrade builds in front of it.
+      Run<?, ?> chain = beyondCap;
+      for (int i = 0; i < 50; i++) {
+        Run<?, ?> step = mock(Run.class);
+        when(step.isBuilding()).thenReturn(false);
+        when(step.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(null);
+        Run<?, ?> next = chain;
+        when(step.getPreviousBuild()).thenAnswer(inv -> next);
+        chain = step;
+      }
+
+      Job<?, ?> job = mock(Job.class);
+      Run<?, ?> head = chain;
+      when(job.getLastBuild()).thenAnswer(inv -> head);
+
+      GitSCM lookupScm = mockGitScmWithUrl("https://host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, lookupScm),
+          "Scan must stop at MAX_BUILDS_TO_SCAN and not walk thousands of pre-upgrade builds");
+    }
+  }
+
+  // Once no recent build records the library, the protection lapses (the
+  // documented limitation of any window-based scan).
+  @Test
+  void testIsRecordedOnlyAsPipelineLibraryFalseWhenWindowHasNoMatch() throws Exception {
+    try (MockedStatic<BitBucketPPRPluginConfig> config =
+        Mockito.mockStatic(BitBucketPPRPluginConfig.class)) {
+      config.when(BitBucketPPRPluginConfig::getInstance).thenReturn(mock(BitBucketPPRPluginConfig.class));
+
+      BitBucketPPRJobProbe probe = new BitBucketPPRJobProbe();
+
+      Run<?, ?> lastBuild = mock(Run.class);
+      when(lastBuild.isBuilding()).thenReturn(false);
+      when(lastBuild.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenReturn(null);
+      when(lastBuild.getPreviousBuild()).thenAnswer(inv -> null);
+
+      Job<?, ?> job = mock(Job.class);
+      when(job.getLastBuild()).thenAnswer(inv -> lastBuild);
+
+      GitSCM scm = mockGitScmWithUrl("ssh://git@host.example.com/org/repo.git");
+      assertFalse(invokeIsRecordedOnlyAsPipelineLibrary(probe, job, scm));
     }
   }
 

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRSCMCheckoutListenerTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRSCMCheckoutListenerTest.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2025, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest;
+
+import static io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction.Classification.NON_LIBRARY_OR_MIXED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction.Classification.ONLY_LIBRARY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import hudson.FilePath;
+import hudson.model.Action;
+import hudson.model.TaskListener;
+import hudson.plugins.git.GitSCM;
+import hudson.scm.SCM;
+import hudson.triggers.Trigger;
+import io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BitBucketPPRSCMCheckoutListenerTest {
+
+  @Test
+  void isPipelineLibraryWorkspaceTrueForLegacyLibsSuffix() {
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc123"));
+    assertTrue(BitBucketPPRSCMCheckoutListener.isPipelineLibraryWorkspace(workspace));
+  }
+
+  // The bare `@libs` suffix (no trailing segment) is intentionally NOT matched:
+  // it collides with user-chosen job names ending in `@libs`. The legacy
+  // retriever always appends a library directory, so `@libs` followed by a path
+  // separator and at least one character is the authoritative shape.
+  @Test
+  void isPipelineLibraryWorkspaceFalseForBareLibsSuffix() {
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs"));
+    assertFalse(BitBucketPPRSCMCheckoutListener.isPipelineLibraryWorkspace(workspace));
+  }
+
+  @Test
+  void isPipelineLibraryWorkspaceFalseForRegularWorkspace() {
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA/ready_for_review"));
+    assertFalse(BitBucketPPRSCMCheckoutListener.isPipelineLibraryWorkspace(workspace));
+  }
+
+  @Test
+  void isPipelineLibraryWorkspaceFalseForLookalikePathSegment() {
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libstuff/abc"));
+    assertFalse(BitBucketPPRSCMCheckoutListener.isPipelineLibraryWorkspace(workspace));
+  }
+
+  @Test
+  void isPipelineLibraryWorkspaceFalseForNull() {
+    assertFalse(BitBucketPPRSCMCheckoutListener.isPipelineLibraryWorkspace(null));
+  }
+
+  @Test
+  void onCheckoutRecordsLibraryWhenWorkspaceMatchesAndJobHasTrigger() throws URISyntaxException {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+
+    GitSCM scm = singleRemoteGitScm("ssh://git@host/org/repo.git");
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc"));
+
+    new BitBucketPPRSCMCheckoutListener()
+        .onCheckout(run, scm, workspace, mock(TaskListener.class), null, null);
+
+    BitBucketPPRPipelineLibrarySCMAction action =
+        run.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+    assertNotNull(action);
+    assertEquals(ONLY_LIBRARY, action.classify(scm),
+        "Library workspace checkout must be recorded as a library");
+  }
+
+  // Non-library checkouts must be recorded too — without them the action would
+  // be unable to tell apart "RepoD is only a library" from "RepoD is a library
+  // and also an explicit checkout".
+  @Test
+  void onCheckoutRecordsNonLibraryWhenWorkspaceDoesNotMatch() throws URISyntaxException {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+
+    GitSCM scm = singleRemoteGitScm("ssh://git@host/org/repo.git");
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA/ready_for_review"));
+
+    new BitBucketPPRSCMCheckoutListener()
+        .onCheckout(run, scm, workspace, mock(TaskListener.class), null, null);
+
+    BitBucketPPRPipelineLibrarySCMAction action =
+        run.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+    assertNotNull(action,
+        "Action must be installed so that future library-only matches can be vetoed");
+    assertEquals(NON_LIBRARY_OR_MIXED, action.classify(scm),
+        "An SCM seen only as a non-library checkout must classify as non-library");
+  }
+
+  // Critical regression test: a job that uses RepoD BOTH as a Pipeline shared
+  // library AND as an explicit checkout in the same build must NOT be excluded
+  // from webhook matching for RepoD — the explicit-checkout half still needs to
+  // react to pushes.
+  @Test
+  void onCheckoutMarksAsNonLibraryWhenSameRepoIsAlsoExplicitlyCheckedOut()
+      throws URISyntaxException {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+
+    GitSCM librarySide = singleRemoteGitScm("ssh://git@host/org/repo.git");
+    GitSCM explicitSide = singleRemoteGitScm("https://host/org/repo.git");
+    FilePath libWorkspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc"));
+    FilePath explicitWorkspace = new FilePath(new File("/jenkins/workspace/RepoA/sub"));
+
+    BitBucketPPRSCMCheckoutListener listener = new BitBucketPPRSCMCheckoutListener();
+    listener.onCheckout(run, librarySide, libWorkspace, mock(TaskListener.class), null, null);
+    listener.onCheckout(run, explicitSide, explicitWorkspace, mock(TaskListener.class), null, null);
+
+    BitBucketPPRPipelineLibrarySCMAction action =
+        run.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+    assertNotNull(action);
+    assertEquals(NON_LIBRARY_OR_MIXED, action.classify(librarySide),
+        "Repo present as BOTH library AND explicit checkout must classify as non-library");
+    assertEquals(NON_LIBRARY_OR_MIXED, action.classify(explicitSide),
+        "Repo present as BOTH library AND explicit checkout must classify as non-library");
+  }
+
+  // Scoping: listener must NOT add the plugin's Action to builds of jobs that
+  // do not use this plugin's trigger, so uninstalling the plugin does not orphan
+  // io.jenkins.plugins.bitbucketpushandpullrequest classes in unrelated builds.
+  @Test
+  void onCheckoutDoesNothingForJobsWithoutBitBucketTrigger() throws URISyntaxException {
+    WorkflowRun run = newRunForJobWithTrigger(false);
+    GitSCM scm = singleRemoteGitScm("ssh://git@host/org/repo.git");
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc"));
+
+    new BitBucketPPRSCMCheckoutListener()
+        .onCheckout(run, scm, workspace, mock(TaskListener.class), null, null);
+
+    verify(run, never()).addAction(any(Action.class));
+  }
+
+  // Idempotency: a second onCheckout call on the same Run must reuse the action
+  // it just installed rather than calling addAction twice.
+  @Test
+  void onCheckoutInstallsActionExactlyOnceAcrossMultipleCheckouts() throws URISyntaxException {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+    GitSCM libA = singleRemoteGitScm("ssh://git@host/org/libA.git");
+    GitSCM libB = singleRemoteGitScm("ssh://git@host/org/libB.git");
+    FilePath wsA = new FilePath(new File("/jenkins/workspace/RepoA@libs/libA"));
+    FilePath wsB = new FilePath(new File("/jenkins/workspace/RepoA@libs/libB"));
+
+    BitBucketPPRSCMCheckoutListener listener = new BitBucketPPRSCMCheckoutListener();
+    listener.onCheckout(run, libA, wsA, mock(TaskListener.class), null, null);
+    listener.onCheckout(run, libB, wsB, mock(TaskListener.class), null, null);
+
+    verify(run, times(1)).addAction(any(BitBucketPPRPipelineLibrarySCMAction.class));
+    BitBucketPPRPipelineLibrarySCMAction action =
+        run.getAction(BitBucketPPRPipelineLibrarySCMAction.class);
+    assertEquals(ONLY_LIBRARY, action.classify(libA));
+    assertEquals(ONLY_LIBRARY, action.classify(libB));
+  }
+
+  // Defensive: a RuntimeException inside the URI extraction must never propagate
+  // out of onCheckout, and must NOT leave an empty action on the Run.
+  @Test
+  void onCheckoutSwallowsRuntimeExceptionsAndDoesNotAttachEmptyAction() {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+    GitSCM brokenScm = mock(GitSCM.class);
+    when(brokenScm.getRepositories()).thenThrow(new RuntimeException("malformed config"));
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc"));
+
+    new BitBucketPPRSCMCheckoutListener()
+        .onCheckout(run, brokenScm, workspace, mock(TaskListener.class), null, null);
+
+    verify(run, never()).addAction(any(Action.class));
+  }
+
+  @Test
+  void onCheckoutIgnoresNonGitScm() {
+    WorkflowRun run = newRunForJobWithTrigger(true);
+    SCM nonGit = mock(SCM.class);
+    FilePath workspace = new FilePath(new File("/jenkins/workspace/RepoA@libs/abc"));
+
+    new BitBucketPPRSCMCheckoutListener()
+        .onCheckout(run, nonGit, workspace, mock(TaskListener.class), null, null);
+
+    verify(run, never()).addAction(any(Action.class));
+  }
+
+  private WorkflowRun newRunForJobWithTrigger(boolean hasTrigger) {
+    WorkflowRun run = mock(WorkflowRun.class);
+    WorkflowJob job = mock(WorkflowJob.class);
+    when(run.getParent()).thenReturn(job);
+
+    if (hasTrigger) {
+      BitBucketPPRTrigger trigger = mock(BitBucketPPRTrigger.class);
+      Map<?, ? extends Trigger<?>> triggers =
+          Map.of(mock(hudson.triggers.TriggerDescriptor.class), trigger);
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      Map<hudson.triggers.TriggerDescriptor, hudson.triggers.Trigger<?>> erased =
+          (Map) triggers;
+      when(job.getTriggers()).thenReturn(erased);
+    } else {
+      when(job.getTriggers()).thenReturn(Map.of());
+    }
+
+    List<Action> actions = new ArrayList<>();
+    when(run.getAction(BitBucketPPRPipelineLibrarySCMAction.class)).thenAnswer(inv ->
+        actions.stream()
+            .filter(BitBucketPPRPipelineLibrarySCMAction.class::isInstance)
+            .map(BitBucketPPRPipelineLibrarySCMAction.class::cast)
+            .findFirst().orElse(null));
+    doAnswer(inv -> {
+      actions.add(inv.getArgument(0));
+      return null;
+    }).when(run).addAction(any(Action.class));
+    when(run.getFullDisplayName()).thenReturn("RepoA #1");
+    return run;
+  }
+
+  private GitSCM singleRemoteGitScm(String url) throws URISyntaxException {
+    GitSCM scm = mock(GitSCM.class);
+    RemoteConfig remote = mock(RemoteConfig.class);
+    when(remote.getURIs()).thenReturn(List.of(new URIish(url)));
+    when(scm.getRepositories()).thenReturn(List.of(remote));
+    return scm;
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPipelineLibrarySCMActionTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/action/BitBucketPPRPipelineLibrarySCMActionTest.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2025, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.action;
+
+import static io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction.Classification.NON_LIBRARY_OR_MIXED;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction.Classification.ONLY_LIBRARY;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.action.BitBucketPPRPipelineLibrarySCMAction.Classification.UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import hudson.plugins.git.GitSCM;
+import java.net.URISyntaxException;
+import java.util.List;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
+import org.junit.jupiter.api.Test;
+
+class BitBucketPPRPipelineLibrarySCMActionTest {
+
+  @Test
+  void classifyOnlyLibraryAcrossUrlSchemes() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+    GitSCM lookup = singleRemoteScm("https://host.example.com/org/repo.git");
+    assertEquals(ONLY_LIBRARY, action.classify(lookup),
+        "Equivalent URLs in different schemes should match via GitStatus.looselyMatches");
+  }
+
+  // Host-case behaviour is delegated to GitStatus.looselyMatches, which today
+  // compares hosts case-sensitively (Objects.equals). The action mirrors that
+  // behaviour deliberately so the negative-match path stays in lockstep with
+  // the probe's positive matchGitScm path.
+  @Test
+  void classifyIsHostCaseSensitiveLikeGitStatusLooselyMatches() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@Bitbucket.Example.COM/org/repo.git"));
+
+    GitSCM lookup = singleRemoteScm("https://bitbucket.example.com/org/repo.git");
+    assertEquals(UNKNOWN, action.classify(lookup),
+        "Host case mismatch must not match — symmetric with GitStatus.looselyMatches");
+  }
+
+  @Test
+  void classifyUnknownForUnrelatedRepository() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+    GitSCM other = singleRemoteScm("ssh://git@host.example.com/org/other.git");
+    assertEquals(UNKNOWN, action.classify(other));
+  }
+
+  // Multi-remote SCM is by construction a real source SCM, never a library
+  // (#378). The classification returns NON_LIBRARY_OR_MIXED rather than UNKNOWN
+  // so the probe's scan stops here instead of regressing to an older build's
+  // ONLY_LIBRARY verdict for a coincidentally-matching URI.
+  @Test
+  void classifyMultiRemoteAsNonLibraryOrMixed() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/lib.git"));
+
+    GitSCM multiRemote = mock(GitSCM.class);
+    RemoteConfig primary = mock(RemoteConfig.class);
+    when(primary.getURIs()).thenReturn(List.of(new URIish("ssh://git@host.example.com/org/primary.git")));
+    RemoteConfig mirror = mock(RemoteConfig.class);
+    when(mirror.getURIs()).thenReturn(List.of(new URIish("ssh://git@host.example.com/org/lib.git")));
+    when(multiRemote.getRepositories()).thenReturn(List.of(primary, mirror));
+
+    assertEquals(NON_LIBRARY_OR_MIXED, action.classify(multiRemote),
+        "Multi-remote GitSCM must classify as NON_LIBRARY_OR_MIXED (preserves #378)");
+  }
+
+  // Same URL recorded as BOTH library AND explicit checkout in this build:
+  // the explicit-checkout half must keep triggering on pushes, so the
+  // classification must be NON_LIBRARY_OR_MIXED.
+  @Test
+  void classifyAsNonLibraryWhenSameRepoIsAlsoExplicit() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+    action.recordNonLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+
+    GitSCM lookup = singleRemoteScm("https://host.example.com/org/repo.git");
+    assertEquals(NON_LIBRARY_OR_MIXED, action.classify(lookup));
+  }
+
+  @Test
+  void classifyDistinguishesLibraryFromExplicitInMixedBuild() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/lib.git"));
+    action.recordNonLibrary(uris("ssh://git@host.example.com/org/source.git"));
+
+    assertEquals(ONLY_LIBRARY, action.classify(singleRemoteScm("https://host.example.com/org/lib.git")));
+    assertEquals(NON_LIBRARY_OR_MIXED,
+        action.classify(singleRemoteScm("https://host.example.com/org/source.git")));
+    assertEquals(UNKNOWN,
+        action.classify(singleRemoteScm("https://host.example.com/org/unrelated.git")));
+  }
+
+  @Test
+  void recordIsIdempotentForLooselyEquivalentUris() throws URISyntaxException {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(uris("ssh://git@host.example.com/org/repo.git"));
+    action.recordLibrary(uris("https://host.example.com/org/repo.git"));
+    action.recordLibrary(uris("git@host.example.com:org/repo.git"));
+
+    action.recordLibrary(uris("ssh://git@host.example.com/org/other.git"));
+    assertEquals(ONLY_LIBRARY,
+        action.classify(singleRemoteScm("ssh://git@host.example.com/org/repo.git")));
+    assertEquals(ONLY_LIBRARY,
+        action.classify(singleRemoteScm("ssh://git@host.example.com/org/other.git")));
+    assertEquals(UNKNOWN,
+        action.classify(singleRemoteScm("ssh://git@host.example.com/org/third.git")));
+  }
+
+  @Test
+  void classifyHandlesNullScm() {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    assertEquals(UNKNOWN, action.classify(null));
+  }
+
+  @Test
+  void recordHandlesNullUris() {
+    BitBucketPPRPipelineLibrarySCMAction action = new BitBucketPPRPipelineLibrarySCMAction();
+    action.recordLibrary(null);
+    action.recordNonLibrary(null);
+    // No throw; classification of an unrelated repo stays UNKNOWN.
+  }
+
+  private static List<URIish> uris(String url) throws URISyntaxException {
+    return List.of(new URIish(url));
+  }
+
+  private GitSCM singleRemoteScm(String url) throws URISyntaxException {
+    GitSCM scm = mock(GitSCM.class);
+    RemoteConfig remote = mock(RemoteConfig.class);
+    when(remote.getURIs()).thenReturn(List.of(new URIish(url)));
+    when(scm.getRepositories()).thenReturn(List.of(remote));
+    return scm;
+  }
+}


### PR DESCRIPTION
## Summary

The shared-library filter introduced for #281 and refined in #378 inferred "this is a Pipeline shared library" from the Git **remote name**. That signal is too weak: libraries loaded via the legacy `SCMRetriever` are checked out as a standalone `GitSCM` whose remote is named `origin`, so they bypass the filter and webhook events on the library repository trigger every job that consumes it (issue #380).

This PR moves the detection signal from "remote name" to "actual role of the checkout in Pipeline":

* **Old filter:** classified a `GitSCM` as a library when its single remote was not named `origin`.
* **New filter:** a new `SCMListener` records each `GitSCM` checkout on the build as either a Pipeline library checkout (workspace path matches `<job-workspace>@libs/<dir>`) or a non-library checkout. At webhook time the probe asks the build's recorded role via a tri-state `classify()` and skips a repository only when it has been recorded *exclusively* as a library across the most recent informative completed build.
* **Protection starts after one build under this version.** The new metadata is populated by `SCMListener.onCheckout`, so a job becomes protected after its first build under the new code. Builds run by older versions still fall back to the legacy remote-name heuristic, which is kept.

The legacy heuristic is retained as a fallback for pre-listener builds and for the non-`origin` shape #281 / #196 originally covered. Multi-remote `GitSCM` is treated as `NON_LIBRARY_OR_MIXED` by construction, preserving the invariant introduced for #378. Jobs that use the same repository both as a library and as an explicit `checkout` still react to pushes for it.

Recorded URIs are sanitized to host + path (the only fields `GitStatus.looselyMatches` consults) and compared via that same upstream API, so the negative-match path stays in lockstep with the probe's positive URL match. The scan walks recent builds under two budgets (`RECENT_BUILDS_WINDOW=10` semantic, `MAX_BUILDS_TO_SCAN=50` operational) and skips in-progress builds whose state may still be partial.

Closes #380. See https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/380#issuecomment-4563143125 for the diagnosis recap and the documented limitations.

## Test plan

- [x] `mvn verify` is green locally (278 tests, 0 failures, spotbugs clean).
- [x] New unit tests cover the action's tri-state classification: cross-scheme match, host case sensitivity, multi-remote treated as non-library, same repo as both library and explicit checkout, idempotent recording, null handling.
- [x] New unit tests cover the listener: workspace regex (positive, bare `@libs` suffix excluded, look-alike segment excluded, null), trigger-scoping (no recording for jobs without `BitBucketPPRTrigger`), idempotency on a second checkout (single `addAction`), exception safety (no empty action on a thrown `getRepositories()`), non-library checkouts are also recorded.
- [x] New unit tests cover the probe's scan window: most-recent-build mixed verdict shadows older library-only entry; in-progress builds are skipped in favour of the most recent completed verdict; the scan stops at `MAX_BUILDS_TO_SCAN` even on long chains of null-action pre-upgrade builds; legacy `isLibrarySCM` and #378 multi-remote regression guards still pass.

## Known limitations (documented in code)

* For multibranch jobs that declare the trigger from the Jenkinsfile via `properties { pipelineTriggers(...) }`, the trigger is attached only after the first checkout, so the first build of a newly discovered branch may not yet be protected by the new metadata-based filter; subsequent builds are. The legacy filter still catches the non-`origin` shape.
* Clone-mode shared libraries checked out under `<build-root>/libs/<dir>` are not detected on remote agents, because the build root is controller-side while the checkout workspace is agent-side. The legacy `@libs` retriever path is the case covered by this fix and is what the #380 reporter's log uses.