### PR TITLE
fix: handle gzip-compressed webhook payloads (Content-Encoding: gzip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 3.3.7 (unreleased)
+
+### Bug Fixes
+* **Handle gzip-compressed webhook payloads from Bitbucket Cloud** - When Bitbucket Cloud sends a webhook with `Content-Encoding: gzip`, the plugin now decompresses the request body before parsing it. Previously, the raw gzip bytes were read as UTF-8, corrupting the payload and causing GSON deserialization to fail silently — `getPullRequest()` returned `null`, the job was never triggered, and Jenkins still returned HTTP 200 to Bitbucket. Fixes #382.
+
 ## 3.3.6 (2026-05-28)
 
 ### Bug Fixes

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -24,12 +24,10 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.io.PushbackInputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 import javax.naming.OperationNotSupportedException;
@@ -130,9 +128,9 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
   }
 
   String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
-    InputStream raw = request.getInputStream();
     boolean gzipHeader = "gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"));
-    try (InputStream body = gzipHeader ? maybeGunzip(raw) : raw) {
+    try (InputStream body = gzipHeader ? GzipUtils.maybeGunzip(request.getInputStream())
+        : request.getInputStream()) {
       String inputStream = IOUtils.toString(body, StandardCharsets.UTF_8);
       if (StringUtils.isBlank(inputStream)) {
         logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
@@ -140,15 +138,6 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
       }
       return decodeInputStream(inputStream, request.getContentType());
     }
-  }
-
-  static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
-    PushbackInputStream pb = new PushbackInputStream(in, 2);
-    byte[] magic = new byte[2];
-    int read = pb.read(magic, 0, 2);
-    pb.unread(magic, 0, read);
-    boolean isGzip = read == 2 && (magic[0] & 0xFF) == 0x1f && (magic[1] & 0xFF) == 0x8b;
-    return isGzip ? new GZIPInputStream(pb) : pb;
   }
 
   BitBucketPPRPayload getPayload(

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -24,6 +24,7 @@ package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.io.PushbackInputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
@@ -130,15 +131,24 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
 
   String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
     InputStream raw = request.getInputStream();
-    if ("gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"))) {
-      raw = new GZIPInputStream(raw);
+    boolean gzipHeader = "gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"));
+    try (InputStream body = gzipHeader ? maybeGunzip(raw) : raw) {
+      String inputStream = IOUtils.toString(body, StandardCharsets.UTF_8);
+      if (StringUtils.isBlank(inputStream)) {
+        logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
+        throw new InputStreamException("The input stream is empty");
+      }
+      return decodeInputStream(inputStream, request.getContentType());
     }
-    String inputStream = IOUtils.toString(raw, StandardCharsets.UTF_8);
-    if (StringUtils.isBlank(inputStream)) {
-      logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
-      throw new InputStreamException("The input stream is empty");
-    }
-    return decodeInputStream(inputStream, request.getContentType());
+  }
+
+  private static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
+    PushbackInputStream pb = new PushbackInputStream(in, 2);
+    byte[] magic = new byte[2];
+    int read = pb.read(magic, 0, 2);
+    pb.unread(magic, 0, read);
+    boolean isGzip = read == 2 && (magic[0] & 0xFF) == 0x1f && (magic[1] & 0xFF) == 0x8b;
+    return isGzip ? new GZIPInputStream(pb) : pb;
   }
 
   BitBucketPPRPayload getPayload(

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -142,7 +142,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     }
   }
 
-  private static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
+  static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
     PushbackInputStream pb = new PushbackInputStream(in, 2);
     byte[] magic = new byte[2];
     int read = pb.read(magic, 0, 2);

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -22,11 +22,13 @@
 package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 import javax.naming.OperationNotSupportedException;
@@ -127,8 +129,11 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
   }
 
   String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
-    // replace The deprecated method toString(InputStream) from the type IOUtils
-    String inputStream = IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
+    InputStream raw = request.getInputStream();
+    if ("gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"))) {
+      raw = new GZIPInputStream(raw);
+    }
+    String inputStream = IOUtils.toString(raw, StandardCharsets.UTF_8);
     if (StringUtils.isBlank(inputStream)) {
       logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
       throw new InputStreamException("The input stream is empty");

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/GzipUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/GzipUtils.java
@@ -3,26 +3,23 @@
  *
  * Copyright (C) 2018-2025, Christian Del Monte.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- * associated documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial documentation files (the "Software"), to deal in the Software without restriction,
- * including without limitation the rights to use, copy, modify, merge, publish, distribute,
- * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- * The above copyright notice and this permission notice shall be included in all copies or
- * substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  ******************************************************************************/
 
 package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
@@ -50,13 +47,23 @@ final class GzipUtils {
    * Wraps {@code in} in a {@link GZIPInputStream} if the stream starts with the gzip magic bytes
    * ({@code 0x1f 0x8b}), otherwise returns the stream unchanged via a {@link PushbackInputStream}.
    *
+   * <p>Uses a fill-loop to read exactly two bytes so the check is safe over real sockets where a
+   * single {@code read()} call may return fewer bytes than requested (e.g. across TCP segment
+   * boundaries). An empty body ({@code read == 0}) is pushed back as a no-op and left to the
+   * caller's blank-check.
+   *
    * <p>The caller is responsible for closing the returned stream.
    */
   static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
     PushbackInputStream pb = new PushbackInputStream(in, 2);
     byte[] magic = new byte[2];
-    int read = pb.read(magic, 0, 2);
-    pb.unread(magic, 0, read);
+    int read = 0, n;
+    while (read < 2 && (n = pb.read(magic, read, 2 - read)) != -1) {
+      read += n;
+    }
+    if (read > 0) {
+      pb.unread(magic, 0, read);
+    }
     boolean isGzip = read == 2 && (magic[0] & 0xFF) == 0x1f && (magic[1] & 0xFF) == 0x8b;
     return isGzip ? new GZIPInputStream(pb) : pb;
   }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/GzipUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/GzipUtils.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2025, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.util.zip.GZIPInputStream;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Utility for transparent gzip decompression of webhook request bodies.
+ *
+ * <p>Bitbucket Cloud sometimes delivers webhook payloads with {@code Content-Encoding: gzip}.
+ * Some fronting proxies decompress the body transparently but leave the header in place.
+ * This utility sniffs the first two magic bytes ({@code 0x1f 0x8b}) to decide whether
+ * decompression is actually needed, rather than trusting the header blindly.
+ */
+final class GzipUtils {
+
+  private GzipUtils() {}
+
+  /**
+   * Wraps {@code in} in a {@link GZIPInputStream} if the stream starts with the gzip magic bytes
+   * ({@code 0x1f 0x8b}), otherwise returns the stream unchanged via a {@link PushbackInputStream}.
+   *
+   * <p>The caller is responsible for closing the returned stream.
+   */
+  static InputStream maybeGunzip(@Nonnull InputStream in) throws IOException {
+    PushbackInputStream pb = new PushbackInputStream(in, 2);
+    byte[] magic = new byte[2];
+    int read = pb.read(magic, 0, 2);
+    pb.unread(magic, 0, read);
+    boolean isGzip = read == 2 && (magic[0] & 0xFF) == 0x1f && (magic[1] & 0xFF) == 0x8b;
+    return isGzip ? new GZIPInputStream(pb) : pb;
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -24,15 +24,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.stream.Stream;
+import java.util.zip.GZIPOutputStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.MockedStatic;
 import org.mockito.MockedStatic.Verification;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -51,6 +57,52 @@ class BitBucketPPRHookReceiverTest {
           .thenReturn(mock(BitBucketPPRPluginConfig.class));
       assertEquals(expected,
           BitBucketPPRHookReceiver.decodeInputStream(inputStream, contentType));
+    }
+  }
+
+  @Test
+  void getInputStream_handlesGzipContentEncoding() throws Exception {
+    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+      gzip.write(expectedJson.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    javax.servlet.ServletInputStream gzipServletStream =
+        new javax.servlet.ServletInputStream() {
+          private final ByteArrayInputStream delegate =
+              new ByteArrayInputStream(baos.toByteArray());
+
+          @Override
+          public int read() {
+            return delegate.read();
+          }
+
+          @Override
+          public boolean isFinished() {
+            return delegate.available() == 0;
+          }
+
+          @Override
+          public boolean isReady() {
+            return true;
+          }
+
+          @Override
+          public void setReadListener(javax.servlet.ReadListener listener) {}
+        };
+
+    StaplerRequest request = mock(StaplerRequest.class);
+    when(request.getHeader("Content-Encoding")).thenReturn("gzip");
+    when(request.getInputStream()).thenReturn(gzipServletStream);
+    when(request.getContentType()).thenReturn("application/json");
+
+    try (MockedStatic<ExtensionList> mocked = mockStatic(ExtensionList.class)) {
+      mocked.when(
+              (Verification) ExtensionList.lookupSingleton(BitBucketPPRPluginConfig.class))
+          .thenReturn(mock(BitBucketPPRPluginConfig.class));
+      BitBucketPPRHookReceiver receiver = new BitBucketPPRHookReceiver();
+      assertEquals(expectedJson, receiver.getInputStream(request));
     }
   }
 

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -65,7 +65,7 @@ class BitBucketPPRHookReceiverTest {
   @Test
   void maybeGunzip_decompressesGzipStream() throws Exception {
     String expected = "{\"pullrequest\":{\"id\":1}}";
-    try (InputStream result = BitBucketPPRHookReceiver.maybeGunzip(
+    try (InputStream result = GzipUtils.maybeGunzip(
         new ByteArrayInputStream(gzip(expected)))) {
       assertEquals(expected, IOUtils.toString(result, StandardCharsets.UTF_8));
     }
@@ -74,9 +74,9 @@ class BitBucketPPRHookReceiverTest {
   @Test
   void maybeGunzip_passesPlainStreamThrough() throws Exception {
     // Simulates a proxy that already decompressed the body but left Content-Encoding: gzip.
-    // maybeGunzip() must detect plain JSON via magic bytes and skip decompression.
+    // GzipUtils.maybeGunzip() detects plain JSON via magic bytes and skips decompression.
     String expected = "{\"pullrequest\":{\"id\":1}}";
-    try (InputStream result = BitBucketPPRHookReceiver.maybeGunzip(
+    try (InputStream result = GzipUtils.maybeGunzip(
         new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8)))) {
       assertEquals(expected, IOUtils.toString(result, StandardCharsets.UTF_8));
     }

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -24,25 +24,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
 
 import hudson.ExtensionList;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.kohsuke.stapler.StaplerRequest;
 import org.mockito.MockedStatic;
 import org.mockito.MockedStatic.Verification;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 
 
 @ExtendWith(MockitoExtension.class)
@@ -62,40 +63,23 @@ class BitBucketPPRHookReceiverTest {
   }
 
   @Test
-  void getInputStream_decompressesGzipBody() throws Exception {
-    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
-    StaplerRequest request = mock(StaplerRequest.class);
-    when(request.getHeader("Content-Encoding")).thenReturn("gzip");
-    when(request.getInputStream()).thenReturn(toServletStream(gzip(expectedJson)));
-    when(request.getContentType()).thenReturn("application/json");
-
-    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
+  void maybeGunzip_decompressesGzipStream() throws Exception {
+    String expected = "{\"pullrequest\":{\"id\":1}}";
+    try (InputStream result = BitBucketPPRHookReceiver.maybeGunzip(
+        new ByteArrayInputStream(gzip(expected)))) {
+      assertEquals(expected, IOUtils.toString(result, StandardCharsets.UTF_8));
+    }
   }
 
   @Test
-  void getInputStream_doesNotDoubleDecompress_whenProxyAlreadyInflated() throws Exception {
-    // Proxy already decompressed the body but left Content-Encoding: gzip header in place.
+  void maybeGunzip_passesPlainStreamThrough() throws Exception {
+    // Simulates a proxy that already decompressed the body but left Content-Encoding: gzip.
     // maybeGunzip() must detect plain JSON via magic bytes and skip decompression.
-    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
-    StaplerRequest request = mock(StaplerRequest.class);
-    when(request.getHeader("Content-Encoding")).thenReturn("gzip");
-    when(request.getInputStream()).thenReturn(
-        toServletStream(expectedJson.getBytes(StandardCharsets.UTF_8)));
-    when(request.getContentType()).thenReturn("application/json");
-
-    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
-  }
-
-  @Test
-  void getInputStream_handlesPlainJsonWithoutContentEncodingHeader() throws Exception {
-    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
-    StaplerRequest request = mock(StaplerRequest.class);
-    when(request.getHeader("Content-Encoding")).thenReturn(null);
-    when(request.getInputStream()).thenReturn(
-        toServletStream(expectedJson.getBytes(StandardCharsets.UTF_8)));
-    when(request.getContentType()).thenReturn("application/json");
-
-    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
+    String expected = "{\"pullrequest\":{\"id\":1}}";
+    try (InputStream result = BitBucketPPRHookReceiver.maybeGunzip(
+        new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8)))) {
+      assertEquals(expected, IOUtils.toString(result, StandardCharsets.UTF_8));
+    }
   }
 
   private static byte[] gzip(String input) throws java.io.IOException {
@@ -104,16 +88,6 @@ class BitBucketPPRHookReceiverTest {
       gz.write(input.getBytes(StandardCharsets.UTF_8));
     }
     return baos.toByteArray();
-  }
-
-  private static javax.servlet.ServletInputStream toServletStream(byte[] bytes) {
-    return new javax.servlet.ServletInputStream() {
-      private final ByteArrayInputStream delegate = new ByteArrayInputStream(bytes);
-      @Override public int read() { return delegate.read(); }
-      @Override public boolean isFinished() { return delegate.available() == 0; }
-      @Override public boolean isReady() { return true; }
-      @Override public void setReadListener(javax.servlet.ReadListener l) {}
-    };
   }
 
   static Stream<Arguments> paramsProvider() {

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -82,6 +82,34 @@ class BitBucketPPRHookReceiverTest {
     }
   }
 
+  @Test
+  void maybeGunzip_decompressesWhenMagicBytesArrivedOneAtATime() throws Exception {
+    // Simulates a real socket where a single read() may return fewer bytes than requested
+    // (e.g. TCP segment boundary splits the two gzip magic bytes across two reads).
+    // The fill-loop in maybeGunzip() must still detect gzip correctly.
+    String expected = "{\"pullrequest\":{\"id\":1}}";
+    byte[] gzipped = gzip(expected);
+    InputStream oneByteAtATime = new InputStream() {
+      private int pos = 0;
+      @Override public int read() { return pos < gzipped.length ? (gzipped[pos++] & 0xFF) : -1; }
+      @Override public int read(byte[] b, int off, int len) {
+        if (pos >= gzipped.length) return -1;
+        b[off] = gzipped[pos++]; // deliberately return only 1 byte per call
+        return 1;
+      }
+    };
+    try (InputStream result = GzipUtils.maybeGunzip(oneByteAtATime)) {
+      assertEquals(expected, IOUtils.toString(result, StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void maybeGunzip_handlesEmptyStream() throws Exception {
+    try (InputStream result = GzipUtils.maybeGunzip(new ByteArrayInputStream(new byte[0]))) {
+      assertEquals("", IOUtils.toString(result, StandardCharsets.UTF_8));
+    }
+  }
+
   private static byte[] gzip(String input) throws java.io.IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverTest.java
@@ -31,6 +31,7 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.Test;
@@ -61,49 +62,58 @@ class BitBucketPPRHookReceiverTest {
   }
 
   @Test
-  void getInputStream_handlesGzipContentEncoding() throws Exception {
+  void getInputStream_decompressesGzipBody() throws Exception {
     String expectedJson = "{\"pullrequest\":{\"id\":1}}";
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
-      gzip.write(expectedJson.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-    }
-
-    javax.servlet.ServletInputStream gzipServletStream =
-        new javax.servlet.ServletInputStream() {
-          private final ByteArrayInputStream delegate =
-              new ByteArrayInputStream(baos.toByteArray());
-
-          @Override
-          public int read() {
-            return delegate.read();
-          }
-
-          @Override
-          public boolean isFinished() {
-            return delegate.available() == 0;
-          }
-
-          @Override
-          public boolean isReady() {
-            return true;
-          }
-
-          @Override
-          public void setReadListener(javax.servlet.ReadListener listener) {}
-        };
-
     StaplerRequest request = mock(StaplerRequest.class);
     when(request.getHeader("Content-Encoding")).thenReturn("gzip");
-    when(request.getInputStream()).thenReturn(gzipServletStream);
+    when(request.getInputStream()).thenReturn(toServletStream(gzip(expectedJson)));
     when(request.getContentType()).thenReturn("application/json");
 
-    try (MockedStatic<ExtensionList> mocked = mockStatic(ExtensionList.class)) {
-      mocked.when(
-              (Verification) ExtensionList.lookupSingleton(BitBucketPPRPluginConfig.class))
-          .thenReturn(mock(BitBucketPPRPluginConfig.class));
-      BitBucketPPRHookReceiver receiver = new BitBucketPPRHookReceiver();
-      assertEquals(expectedJson, receiver.getInputStream(request));
+    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
+  }
+
+  @Test
+  void getInputStream_doesNotDoubleDecompress_whenProxyAlreadyInflated() throws Exception {
+    // Proxy already decompressed the body but left Content-Encoding: gzip header in place.
+    // maybeGunzip() must detect plain JSON via magic bytes and skip decompression.
+    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
+    StaplerRequest request = mock(StaplerRequest.class);
+    when(request.getHeader("Content-Encoding")).thenReturn("gzip");
+    when(request.getInputStream()).thenReturn(
+        toServletStream(expectedJson.getBytes(StandardCharsets.UTF_8)));
+    when(request.getContentType()).thenReturn("application/json");
+
+    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
+  }
+
+  @Test
+  void getInputStream_handlesPlainJsonWithoutContentEncodingHeader() throws Exception {
+    String expectedJson = "{\"pullrequest\":{\"id\":1}}";
+    StaplerRequest request = mock(StaplerRequest.class);
+    when(request.getHeader("Content-Encoding")).thenReturn(null);
+    when(request.getInputStream()).thenReturn(
+        toServletStream(expectedJson.getBytes(StandardCharsets.UTF_8)));
+    when(request.getContentType()).thenReturn("application/json");
+
+    assertEquals(expectedJson, new BitBucketPPRHookReceiver().getInputStream(request));
+  }
+
+  private static byte[] gzip(String input) throws java.io.IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+      gz.write(input.getBytes(StandardCharsets.UTF_8));
     }
+    return baos.toByteArray();
+  }
+
+  private static javax.servlet.ServletInputStream toServletStream(byte[] bytes) {
+    return new javax.servlet.ServletInputStream() {
+      private final ByteArrayInputStream delegate = new ByteArrayInputStream(bytes);
+      @Override public int read() { return delegate.read(); }
+      @Override public boolean isFinished() { return delegate.available() == 0; }
+      @Override public boolean isReady() { return true; }
+      @Override public void setReadListener(javax.servlet.ReadListener l) {}
+    };
   }
 
   static Stream<Arguments> paramsProvider() {


### PR DESCRIPTION
## Summary

Fixes #382.

When Bitbucket Cloud sends a webhook with `Content-Encoding: gzip`, the plugin now decompresses the request body before parsing it. Previously, the raw gzip bytes were read directly as UTF-8, corrupting the payload and causing GSON deserialization to fail silently — `getPullRequest()` returned `null`, the job was never triggered, and Jenkins still returned HTTP 200 to Bitbucket.

## Changes

### `BitBucketPPRHookReceiver.java`

Added gzip decompression in `getInputStream()` by checking the `Content-Encoding` header before reading the stream:

```java
InputStream raw = request.getInputStream();
if ("gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"))) {
  raw = new GZIPInputStream(raw);
}
String inputStream = IOUtils.toString(raw, StandardCharsets.UTF_8);
```

### `BitBucketPPRHookReceiverTest.java`

Added `getInputStream_handlesGzipContentEncoding()` test that:
1. Compresses a JSON payload with `GZIPOutputStream`
2. Mocks a `StaplerRequest` with `Content-Encoding: gzip` header
3. Asserts the decompressed string matches the original JSON

### `CHANGELOG.md`

Added entry for the upcoming 3.3.7 release.

## How it was discovered

This issue was observed in production with Bitbucket Cloud webhooks behind a Cloudflare CDN proxy. Bitbucket Cloud intermittently sends webhook payloads with `Content-Encoding: gzip`. The gzip bytes were confirmed via Apache `mod_dumpio` logging — the raw bytes arriving at the server started with the gzip magic bytes (`\x1f\x8b`).

The fix was first validated by introducing a Cloudflare Worker proxy that preserved the binary `arrayBuffer()` (instead of using `text()` which corrupted the gzip stream), allowing Jetty/Apache to decompress it before it reached the plugin. The correct fix is to handle decompression inside the plugin itself.

## Test environment

> Note: tests require Java 17 or 21. The local environment used Java 24, which is not yet supported by the Byte Buddy version used by Mockito in this project. The fix and new test were validated against the project's CI pipeline.