### PR TITLE
feat: support Bitbucket webhook secrets via X-Hub-Signature validation (#360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 3.4.0 (unreleased)
+
+### Features
+* **Support Bitbucket webhook secrets** - The plugin can now authenticate incoming webhook deliveries. A new *Webhook secret* option in the global configuration selects a *Secret text* credential holding the secret configured on the Bitbucket webhooks. When set, every request to the webhook endpoint must carry a valid `X-Hub-Signature` header: the hex-encoded HMAC-SHA256 of the request body, prefixed with `sha256=`, as sent by both Bitbucket Cloud and Bitbucket Server / Data Center when a secret is configured on the webhook. Requests with a missing or invalid signature are rejected with **HTTP 403** before any payload processing; an unresolvable secret credential fails closed. The signature is validated on the decompressed body, so gzip-compressed deliveries keep working. When no secret is configured the behaviour is unchanged and unsigned requests are accepted as before. Fixes #360.
+
 ## 3.3.9 (2026-06-16)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ in the __Jenkins Global Configurations__:
 8. you can disable the `BITBUCKET_PULL_REQUEST_DESCRIPTION` environment variable to avoid exceeding the Linux
    `MAX_ARG_STRLEN` limit when the pull request description is too large
 
+9. you can set a webhook secret (as a *Secret text* credential) to authenticate incoming webhook deliveries: when set,
+   every request to the webhook endpoint must carry a valid `X-Hub-Signature` header (the HMAC-SHA256 of the request
+   body, sent by Bitbucket Cloud and Bitbucket Server / Data Center when a secret is configured on the webhook), and
+   requests with a missing or invalid signature are rejected with HTTP 403. The same secret must be configured on every
+   webhook pointing to the Jenkins instance
+
 ![example global config jenkins bb ppr 1](docs/img/global-config.png)
 
 ## Configure your Jenkins job

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/common/BitBucketPPRConst.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/common/BitBucketPPRConst.java
@@ -56,6 +56,7 @@ public final class BitBucketPPRConst {
   public static final String PULL_REQUEST_PARTICIPANT = "PARTICIPANT";
   public static final String DEPRECATED_X_HEADER_REPO_POST = "repo:post";
   public static final String X_EVENT_KEY = "x-event-key";
+  public static final String X_HUB_SIGNATURE = "x-hub-signature";
   public static final String PAYLOAD_PFX = "payload=";
 
   public static final String APPLICATION_X_WWW_FORM_URLENCODED =

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig.java
@@ -36,8 +36,11 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.verb.POST;
 
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -63,6 +66,8 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   public boolean useJobNameAsBuildKey;
 
   public String credentialsId;
+
+  public String webhookSecretCredentialsId;
 
   public String singleJob;
 
@@ -180,6 +185,38 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
   }
 
   @DataBoundSetter
+  public void setWebhookSecretCredentialsId(@CheckForNull String webhookSecretCredentialsId) {
+    this.webhookSecretCredentialsId = webhookSecretCredentialsId;
+    save();
+  }
+
+  public String getWebhookSecretCredentialsId() {
+    return webhookSecretCredentialsId;
+  }
+
+  public boolean isWebhookSecretSet() {
+    return !isEmpty(webhookSecretCredentialsId);
+  }
+
+  /**
+   * Resolves the configured webhook secret credential to its plain text, or returns null when no
+   * credential is configured or the configured id cannot be resolved. The credential is looked up
+   * on every call so that rotating the secret takes effect without a restart.
+   */
+  @CheckForNull
+  public String getWebhookSecret() {
+    if (!isWebhookSecretSet()) {
+      return null;
+    }
+    StringCredentials credentials = CredentialsMatchers.firstOrNull(
+        CredentialsProvider.lookupCredentialsInItemGroup(StringCredentials.class, Jenkins.get(),
+            ACL.SYSTEM2, Collections.emptyList()),
+        CredentialsMatchers.withId(webhookSecretCredentialsId));
+
+    return credentials == null ? null : credentials.getSecret().getPlainText();
+  }
+
+  @DataBoundSetter
   public void setSingleJob(String singleJob) {
     if (isEmpty(singleJob)) {
       this.singleJob = "";
@@ -230,5 +267,24 @@ public class BitBucketPPRPluginConfig extends GlobalConfiguration {
             Collections.emptyList(),
             CredentialsMatchers.always())
         .includeCurrentValue(credentialsId);
+  }
+
+  @POST
+  public ListBoxModel doFillWebhookSecretCredentialsIdItems(
+      @QueryParameter String webhookSecretCredentialsId) {
+
+    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+      return new StandardListBoxModel().includeCurrentValue(webhookSecretCredentialsId);
+    }
+
+    return new StandardListBoxModel()
+        .includeEmptyValue()
+        .includeMatchingAs(
+            ACL.SYSTEM2,
+            Jenkins.get(),
+            StringCredentials.class,
+            Collections.emptyList(),
+            CredentialsMatchers.always())
+        .includeCurrentValue(webhookSecretCredentialsId);
   }
 }

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiver.java
@@ -50,6 +50,7 @@ import hudson.model.UnprotectedRootAction;
 import hudson.security.csrf.CrumbExclusion;
 import io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst;
 import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.HOOK_URL;
+import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.X_HUB_SIGNATURE;
 import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.BitBucketPPRPayloadPropertyNotFoundException;
 import io.jenkins.plugins.bitbucketpushandpullrequest.exception.InputStreamException;
@@ -70,8 +71,6 @@ import io.jenkins.plugins.bitbucketpushandpullrequest.processor.BitBucketPPRPayl
 @Extension
 public class BitBucketPPRHookReceiver extends CrumbExclusion implements UnprotectedRootAction {
   private static final Logger logger = Logger.getLogger(BitBucketPPRHookReceiver.class.getName());
-  private static final BitBucketPPRPluginConfig globalConfig =
-      BitBucketPPRPluginConfig.getInstance();
 
   @POST
   public void doIndex(@Nonnull StaplerRequest request, @Nonnull StaplerResponse response)
@@ -85,8 +84,22 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
       System.out.println(">>> Received POST request over Bitbucket hook");
 
       try {
+        byte[] body = readBody(request);
+
+        // Authenticate the request before doing anything with its content: when a webhook
+        // secret is configured, every delivery must carry an X-Hub-Signature header with a
+        // valid HMAC-SHA256 of the request body (issue #360). Bitbucket signs the payload
+        // before any transport encoding, so the signature is checked on the decompressed,
+        // not-yet-URL-decoded body.
+        if (BitBucketPPRPluginConfig.getInstance().isWebhookSecretSet()
+            && !isSignatureValid(request, body)) {
+          writeForbiddenResponse(response);
+          return;
+        }
+
         BitBucketPPRHookEvent bitbucketEvent = getBitbucketEvent(request);
-        BitBucketPPRPayload payload = getPayload(getInputStream(request), bitbucketEvent);
+        BitBucketPPRPayload payload =
+            getPayload(bodyToString(body, request.getContentType()), bitbucketEvent);
 
         BitBucketPPRPayloadProcessor processor;
         try {
@@ -156,7 +169,7 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_OK);
     PrintWriter out = response.getWriter();
-    out.write("Bitbuckt PPR Plugin: request received successfully.");
+    out.write("Bitbucket PPR Plugin: request received successfully.");
     out.flush();
     out.close();
   }
@@ -166,22 +179,63 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
     PrintWriter out = response.getWriter();
-    out.write("Bitbuckt PPR Plugin: request failed.");
+    out.write("Bitbucket PPR Plugin: request failed.");
     out.flush();
     out.close();
   }
 
-  String getInputStream(@Nonnull StaplerRequest request) throws IOException, InputStreamException {
+  private void writeForbiddenResponse(@Nonnull StaplerResponse response) throws IOException {
+    response.setContentType("text/html");
+    response.setCharacterEncoding("UTF-8");
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    PrintWriter out = response.getWriter();
+    out.write("Bitbucket PPR Plugin: request rejected: missing or invalid signature.");
+    out.flush();
+    out.close();
+  }
+
+  /**
+   * Reads the raw request body, transparently gunzipping it when the request was delivered with
+   * {@code Content-Encoding: gzip}. The bytes are returned before any URL decoding because the
+   * webhook signature, when present, is computed over exactly these bytes.
+   */
+  byte[] readBody(@Nonnull StaplerRequest request) throws IOException {
     boolean gzipHeader = "gzip".equalsIgnoreCase(request.getHeader("Content-Encoding"));
     try (InputStream body = gzipHeader ? GzipUtils.maybeGunzip(request.getInputStream())
         : request.getInputStream()) {
-      String inputStream = IOUtils.toString(body, StandardCharsets.UTF_8);
-      if (StringUtils.isBlank(inputStream)) {
-        logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
-        throw new InputStreamException("The input stream is empty");
-      }
-      return decodeInputStream(inputStream, request.getContentType());
+      return IOUtils.toByteArray(body);
     }
+  }
+
+  String bodyToString(@Nonnull byte[] body, String contentType) throws InputStreamException {
+    String inputStream = new String(body, StandardCharsets.UTF_8);
+    if (StringUtils.isBlank(inputStream)) {
+      logger.severe("The Jenkins job cannot be triggered. The input stream is empty.");
+      throw new InputStreamException("The input stream is empty");
+    }
+    return decodeInputStream(inputStream, contentType);
+  }
+
+  /**
+   * Validates the {@code X-Hub-Signature} header against the configured webhook secret. Returns
+   * false -- rejecting the request -- when the configured secret credential cannot be resolved
+   * (fail closed) or when the signature is missing, malformed or does not match.
+   */
+  private boolean isSignatureValid(@Nonnull StaplerRequest request, @Nonnull byte[] body) {
+    String secret = BitBucketPPRPluginConfig.getInstance().getWebhookSecret();
+    if (StringUtils.isBlank(secret)) {
+      logger.severe(
+          "A webhook secret credential is configured but could not be resolved to a non-empty "
+              + "secret; the request is rejected.");
+      return false;
+    }
+    if (!SignatureUtils.isValid(body, request.getHeader(X_HUB_SIGNATURE), secret)) {
+      logger.warning(
+          "The webhook request signature is missing or does not match the configured secret; "
+              + "the request is rejected.");
+      return false;
+    }
+    return true;
   }
 
   BitBucketPPRPayload getPayload(
@@ -237,6 +291,10 @@ public class BitBucketPPRHookReceiver extends CrumbExclusion implements Unprotec
 
   @Override
   public String getUrlName() {
+    // Resolved per call rather than cached in a static field: a static would pin the
+    // GlobalConfiguration instance of whichever Jenkins was alive when this class loaded,
+    // going stale across Jenkins instances (e.g. JenkinsRule tests in the same JVM).
+    BitBucketPPRPluginConfig globalConfig = BitBucketPPRPluginConfig.getInstance();
     return (globalConfig.isHookUrlSet() ? globalConfig.getHookUrl() : HOOK_URL).toLowerCase();
   }
 

--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/SignatureUtils.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/SignatureUtils.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * The MIT License
+ *
+ * Copyright (C) 2018-2026, Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ ******************************************************************************/
+
+package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility for validating webhook request signatures.
+ *
+ * <p>When a secret is configured on a Bitbucket webhook, Bitbucket Cloud and Bitbucket Server /
+ * Data Center sign every delivery with an {@code X-Hub-Signature} header of the form
+ * {@code sha256=&lt;hex&gt;}, where {@code &lt;hex&gt;} is the HMAC-SHA256 of the request body
+ * computed with the secret as key. The signature covers the payload before any transport
+ * encoding, so it must be validated against the request body after gzip decompression but before
+ * any URL decoding.
+ */
+final class SignatureUtils {
+
+  private static final String SHA256_PREFIX = "sha256=";
+  private static final String HMAC_SHA256 = "HmacSHA256";
+
+  private SignatureUtils() {}
+
+  /**
+   * Returns true if {@code signatureHeader} is a well-formed {@code sha256=&lt;hex&gt;} signature
+   * whose HMAC-SHA256 matches {@code body} under {@code secret}. A missing, blank or malformed
+   * header never validates. The hex comparison is case-insensitive and constant-time.
+   */
+  static boolean isValid(
+      @Nonnull byte[] body, @CheckForNull String signatureHeader, @Nonnull String secret) {
+    if (StringUtils.isBlank(signatureHeader)
+        || !StringUtils.startsWithIgnoreCase(signatureHeader, SHA256_PREFIX)) {
+      return false;
+    }
+    String providedHex =
+        signatureHeader.substring(SHA256_PREFIX.length()).trim().toLowerCase(Locale.ROOT);
+
+    byte[] computed;
+    try {
+      Mac mac = Mac.getInstance(HMAC_SHA256);
+      mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));
+      computed = mac.doFinal(body);
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      // HmacSHA256 is mandatory on every JVM and the key is non-blank by the caller's contract.
+      throw new IllegalStateException("HMAC-SHA256 is unavailable", e);
+    }
+
+    return MessageDigest.isEqual(
+        toHex(computed).getBytes(StandardCharsets.US_ASCII),
+        providedHex.getBytes(StandardCharsets.US_ASCII));
+  }
+
+  private static String toHex(@Nonnull byte[] bytes) {
+    StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig/config.jelly
@@ -24,6 +24,9 @@
         <f:entry title="${%Credentials}" field="credentialsId">
             <f:select/>
         </f:entry>
+        <f:entry title="${%Webhook secret}" field="webhookSecretCredentialsId">
+            <f:select/>
+        </f:entry>
         <f:entry title="Propagation URL" field="propagationUrlTitle">
             <f:textbox field="propagationUrl"/>
         </f:entry>

--- a/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig/help-webhookSecretCredentialsId.html
+++ b/src/main/resources/io/jenkins/plugins/bitbucketpushandpullrequest/config/BitBucketPPRPluginConfig/help-webhookSecretCredentialsId.html
@@ -1,0 +1,9 @@
+<div>
+  Optional. Select a <b>Secret text</b> credential holding the secret configured on your Bitbucket
+  webhooks. When set, every incoming webhook request must carry a valid
+  <code>X-Hub-Signature</code> header: the HMAC-SHA256 of the request body, hex-encoded and
+  prefixed with <code>sha256=</code>, as sent by Bitbucket Cloud and Bitbucket Server / Data Center
+  when a secret is configured on the webhook. Requests with a missing or invalid signature are
+  rejected with HTTP 403. Leave empty to keep accepting unsigned requests. The same secret must be
+  configured on every webhook pointing to this Jenkins instance.
+</div>

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverSignatureTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/BitBucketPPRHookReceiverSignatureTest.java
@@ -1,0 +1,163 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018-2026 Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
+
+import static io.jenkins.plugins.bitbucketpushandpullrequest.common.BitBucketPPRConst.HOOK_URL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+
+import hudson.util.Secret;
+import io.jenkins.plugins.bitbucketpushandpullrequest.config.BitBucketPPRPluginConfig;
+
+/**
+ * End-to-end check of the webhook signature validation (issue #360): when a webhook secret is
+ * configured, requests must carry a valid {@code X-Hub-Signature} header (HMAC-SHA256 of the
+ * request body) or be rejected with HTTP 403 before any payload processing. Without a configured
+ * secret the previous behaviour is unchanged.
+ */
+@WithJenkins
+class BitBucketPPRHookReceiverSignatureTest {
+
+  private static final String CREDENTIALS_ID = "bitbucket-webhook-secret";
+  private static final String WEBHOOK_SECRET = "It's a Secret to Everybody";
+
+  // diagnostics:ping with an empty JSON object is acknowledged with 200 once authenticated
+  // (see BitBucketPPRHookReceiverResponseStatusTest).
+  private static final String PING_EVENT = "diagnostics:ping";
+  private static final String PING_BODY = "{}";
+
+  private JenkinsRule j;
+
+  @BeforeEach
+  void setUp(JenkinsRule rule) throws Exception {
+    j = rule;
+    SystemCredentialsProvider.getInstance().getCredentials().add(new StringCredentialsImpl(
+        CredentialsScope.GLOBAL, CREDENTIALS_ID, "webhook secret",
+        Secret.fromString(WEBHOOK_SECRET)));
+    SystemCredentialsProvider.getInstance().save();
+    BitBucketPPRPluginConfig.getInstance().setWebhookSecretCredentialsId(CREDENTIALS_ID);
+  }
+
+  @Test
+  void signedRequestIsAccepted() throws Exception {
+    assertEquals(200, post(PING_EVENT, PING_BODY.getBytes(StandardCharsets.UTF_8),
+        signature(PING_BODY, WEBHOOK_SECRET), false));
+  }
+
+  @Test
+  void unsignedRequestIsRejected() throws Exception {
+    assertEquals(403, post(PING_EVENT, PING_BODY.getBytes(StandardCharsets.UTF_8), null, false));
+  }
+
+  @Test
+  void wrongSignatureIsRejected() throws Exception {
+    assertEquals(403, post(PING_EVENT, PING_BODY.getBytes(StandardCharsets.UTF_8),
+        signature(PING_BODY, "some other secret"), false));
+  }
+
+  @Test
+  void gzippedBodyValidatesAgainstUncompressedBytes() throws Exception {
+    // Bitbucket signs the payload before any transport encoding: the signature is computed over
+    // the uncompressed JSON even when the delivery arrives with Content-Encoding: gzip.
+    assertEquals(200, post(PING_EVENT, gzip(PING_BODY),
+        signature(PING_BODY, WEBHOOK_SECRET), true));
+  }
+
+  @Test
+  void unresolvableCredentialFailsClosed() throws Exception {
+    BitBucketPPRPluginConfig.getInstance().setWebhookSecretCredentialsId("no-such-credential");
+    assertEquals(403, post(PING_EVENT, PING_BODY.getBytes(StandardCharsets.UTF_8),
+        signature(PING_BODY, WEBHOOK_SECRET), false));
+  }
+
+  @Test
+  void noConfiguredSecretIgnoresSignatureHeader() throws Exception {
+    BitBucketPPRPluginConfig.getInstance().setWebhookSecretCredentialsId("");
+    assertEquals(200, post(PING_EVENT, PING_BODY.getBytes(StandardCharsets.UTF_8),
+        "sha256=0000000000000000000000000000000000000000000000000000000000000000", false));
+  }
+
+  @Test
+  void signedButMalformedPayloadIsStillRejectedWithBadRequest() throws Exception {
+    // Authentication passes, then payload validation (#384) still applies: 400, not 200.
+    String body = "{}";
+    assertEquals(400, post("pullrequest:created", body.getBytes(StandardCharsets.UTF_8),
+        signature(body, WEBHOOK_SECRET), false));
+  }
+
+  private int post(String eventKey, byte[] body, String signatureHeader, boolean gzipped)
+      throws Exception {
+    URL url = new URL(j.getURL(), HOOK_URL + "/");
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    try {
+      connection.setRequestMethod("POST");
+      connection.setDoOutput(true);
+      connection.setRequestProperty("x-event-key", eventKey);
+      connection.setRequestProperty("content-type", "application/json");
+      if (signatureHeader != null) {
+        connection.setRequestProperty("x-hub-signature", signatureHeader);
+      }
+      if (gzipped) {
+        connection.setRequestProperty("Content-Encoding", "gzip");
+      }
+      connection.getOutputStream().write(body);
+      return connection.getResponseCode();
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  private static String signature(String body, String secret) throws Exception {
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+    StringBuilder sb = new StringBuilder("sha256=");
+    for (byte b : mac.doFinal(body.getBytes(StandardCharsets.UTF_8))) {
+      sb.append(String.format("%02x", b));
+    }
+    return sb.toString();
+  }
+
+  private static byte[] gzip(String input) throws java.io.IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+      gz.write(input.getBytes(StandardCharsets.UTF_8));
+    }
+    return out.toByteArray();
+  }
+}

--- a/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/SignatureUtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/bitbucketpushandpullrequest/receiver/SignatureUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018-2026 Christian Del Monte.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.jenkins.plugins.bitbucketpushandpullrequest.receiver;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+class SignatureUtilsTest {
+
+  // Known-answer vector for HMAC-SHA256 webhook signatures (same scheme used by Bitbucket):
+  // verified independently with `printf '%s' 'Hello, World!' | openssl dgst -sha256 -hmac ...`.
+  private static final String SECRET = "It's a Secret to Everybody";
+  private static final byte[] BODY = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+  private static final String SIGNATURE =
+      "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+
+  @Test
+  void validSignatureIsAccepted() {
+    assertTrue(SignatureUtils.isValid(BODY, SIGNATURE, SECRET));
+  }
+
+  @Test
+  void uppercaseHexAndPrefixAreAccepted() {
+    assertTrue(SignatureUtils.isValid(BODY, SIGNATURE.toUpperCase(Locale.ROOT), SECRET));
+  }
+
+  @Test
+  void emptyBodySignatureIsAccepted() {
+    // printf '' | openssl dgst -sha256 -hmac "It's a Secret to Everybody"
+    assertTrue(SignatureUtils.isValid(new byte[0],
+        "sha256=66a0c074deaa0f489ead6537e0d32f9a344b90bbeda705b6ed45ecd3b413fb40", SECRET));
+  }
+
+  @Test
+  void tamperedBodyIsRejected() {
+    byte[] tampered = "Hello, World?".getBytes(StandardCharsets.UTF_8);
+    assertFalse(SignatureUtils.isValid(tampered, SIGNATURE, SECRET));
+  }
+
+  @Test
+  void wrongSecretIsRejected() {
+    assertFalse(SignatureUtils.isValid(BODY, SIGNATURE, "some other secret"));
+  }
+
+  @Test
+  void missingHeaderIsRejected() {
+    assertFalse(SignatureUtils.isValid(BODY, null, SECRET));
+    assertFalse(SignatureUtils.isValid(BODY, "", SECRET));
+    assertFalse(SignatureUtils.isValid(BODY, "   ", SECRET));
+  }
+
+  @Test
+  void unsupportedAlgorithmPrefixIsRejected() {
+    assertFalse(SignatureUtils.isValid(BODY,
+        "sha1=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17", SECRET));
+  }
+
+  @Test
+  void malformedHexIsRejected() {
+    assertFalse(SignatureUtils.isValid(BODY, "sha256=not-hex-at-all", SECRET));
+    assertFalse(SignatureUtils.isValid(BODY, "sha256=", SECRET));
+  }
+}


### PR DESCRIPTION
Implements webhook secret support requested in #360.

## What

When a secret is configured on a Bitbucket webhook, Bitbucket Cloud and Bitbucket Server / Data Center sign every delivery with an `X-Hub-Signature` header of the form `sha256=<hex>`, where `<hex>` is the HMAC-SHA256 of the request body computed with the secret as key. Until now the plugin ignored that header: the endpoint is an `UnprotectedRootAction`, so anyone able to reach Jenkins could POST a forged payload and trigger jobs.

This PR adds an optional **Webhook secret** to the plugin's global configuration, selecting a *Secret text* credential. When set:

- every request to the webhook endpoint must carry a valid `X-Hub-Signature` header;
- a missing, malformed or non-matching signature is rejected with **HTTP 403**, before any payload parsing or acknowledgement;
- a configured but unresolvable secret credential fails closed (403), with a SEVERE log;
- the hex comparison is constant-time (`MessageDigest.isEqual`).

When no secret is configured, behaviour is unchanged: unsigned requests are accepted as before, and a stray signature header is ignored.

## Design notes

- **Signature vs. transport encoding.** Bitbucket signs the payload before any transport encoding, so the signature is validated on the request body *after* gzip decompression (#382/#383) but *before* the URL decoding of the legacy form-encoded path. `getInputStream` was split accordingly into `readBody` (raw bytes, post-gunzip — the HMAC input) and `bodyToString` (blank-check + decode, unchanged semantics).
- **Validation order.** Authentication runs first; the payload validation boundaries from #384 still apply afterwards (a signed but malformed payload returns 400, covered by a test).
- **Global, not per-job.** Validation happens at the receiver, before job matching, so the secret is global — same model as other plugins' shared webhook secret. The same secret must be configured on every webhook pointing to the Jenkins instance. Per-webhook secrets could be layered later if requested.
- **Receiver no longer caches the config in a static field.** The `static final` pinned the `GlobalConfiguration` instance of whichever Jenkins was alive when the class loaded, going stale across Jenkins instances (e.g. `JenkinsRule` tests in the same JVM). It is now resolved per call, like everywhere else in Jenkins.
- The credential is resolved on every request, so rotating the secret takes effect without a restart.

## Tests

- `SignatureUtilsTest` (unit): known-answer vector verified independently with `openssl dgst -sha256 -hmac`, case-insensitive hex/prefix, empty body, tampered body, wrong secret, missing/blank header, `sha1=` prefix, malformed hex.
- `BitBucketPPRHookReceiverSignatureTest` (`@WithJenkins`, e2e over HTTP): signed request accepted (200), unsigned/wrong-signature rejected (403), gzip-compressed delivery validated against the uncompressed bytes (200), unresolvable credential fails closed (403), no configured secret ignores the header (200), signed but malformed payload still rejected by #384 validation (400).

Full suite green locally (311 run, 0 failures, 12 pre-existing skips) on JDK 17.

Fixes #360.
