### PR TITLE
fix: use SCMHead for PR job matching instead of display name

### DIFF
--- a/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
+++ b/src/main/java/io/jenkins/plugins/bitbucketpushandpullrequest/BitBucketPPRJobProbe.java
@@ -45,6 +45,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import jenkins.branch.MultiBranchProject;
+import jenkins.scm.api.SCMHead;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
@@ -253,6 +254,19 @@ public class BitBucketPPRJobProbe {
       }
 
       if (sourceBranchName != null) {
+        // For PR events, check if this job is associated with the PR's source branch
+        // via the SCMHead. This works regardless of the job's display name which may
+        // be set to the PR title by bitbucket-branch-source plugin.
+        SCMHead head = SCMHead.HeadByItem.findHead(job);
+        if (head != null) {
+          String headName = head.getName();
+          if (sourceBranchName.equalsIgnoreCase(headName)) {
+            return false; // trigger this job
+          }
+          return true; // different branch/PR, skip
+        }
+
+        // Fallback for jobs without an SCMHead: exact match on display name
         return !displayName.equalsIgnoreCase(sourceBranchName);
       }
 


### PR DESCRIPTION
The bitbucket-branch-source plugin sets the display name of PR jobs to the PR title (e.g. 'release(demo-api): - release/next (#11)') rather than the raw branch name. This causes mPJobShouldNotBeTriggered to skip PR jobs because displayName != sourceBranchName.

Fix by using SCMHead.HeadByItem.findHead(job) to get the actual branch/PR association from the SCM API, which works regardless of the job's display name.

### Testing done

Manual testing against Bitbucket Cloud:

Set up a multibranch pipeline with cloudbees-bitbucket-branch-source pointing at a Bitbucket Cloud repository

Created a PR from branch release/next → main

The bitbucket-branch-source plugin names the job using the PR title: release(demo-bb-api): - release/next (https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/11)

Configured bitBucketTrigger with BitBucketPPRPullRequestCommentCreatedActionFilter
Posted a PR comment matching the filter regex

Before fix: Jenkins log shows:

```
FINEST BitBucketPPRJobProbe mPJobShouldNotBeTriggered
Bitbucket event is: comment_created, Job Name: release(demo-bb-api): - release/next (https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/11), sourceBranchName: release/next, targetBranchName: main
FINEST BitBucketPPRJobProbe lambda$triggerScm$7
Skipping job release(demo-bb-api): - release/next (https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/11).
Job is skipped because "release(demo-bb-api): - release/next (https://github.com/jenkinsci/bitbucket-push-and-pull-request-plugin/issues/11)".equalsIgnoreCase("release/next") → false
```

After fix: SCMHead.HeadByItem.findHead(job).getName() returns release/next which matches sourceBranchName, so the job triggers correctly.

No automated test added — the existing test infrastructure does not mock SCMHead.HeadByItem interactions with the bitbucket-branch-source plugin. The fix uses scm-api (already a dependency) and gracefully falls back to the existing displayName comparison when no SCMHead is found.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira -  Fixes #388 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

